### PR TITLE
Don't prematurely close connection for LogStreams

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -34,14 +34,26 @@ type Engine struct {
 	Endpoint      string        `json:"endpoint"`
 }
 
-func NewLogStream(stream rpc.ProcessManagerService_ProcessLogClient) *LogStream {
+func NewLogStream(conn *grpc.ClientConn, ctxCancel context.CancelFunc, stream rpc.ProcessManagerService_ProcessLogClient) *LogStream {
 	return &LogStream{
-		stream: stream,
+		conn,
+		ctxCancel,
+		stream,
 	}
 }
 
 type LogStream struct {
-	stream rpc.ProcessManagerService_ProcessLogClient
+	conn      *grpc.ClientConn
+	ctxCancel context.CancelFunc
+	stream    rpc.ProcessManagerService_ProcessLogClient
+}
+
+func (s *LogStream) Close() error {
+	s.ctxCancel()
+	if err := s.conn.Close(); err != nil {
+		return errors.Wrapf(err, "error closing logs gRPC connection")
+	}
+	return nil
 }
 
 func (s *LogStream) Recv() (string, error) {

--- a/client/engine_manager.go
+++ b/client/engine_manager.go
@@ -207,12 +207,9 @@ func (cli *EngineManagerClient) EngineLog(volumeName string) (*api.LogStream, er
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to EngineManager Service %v: %v", cli.Address, err)
 	}
-	defer conn.Close()
+
 	client := rpc.NewEngineManagerServiceClient(conn)
-
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
-	defer cancel()
-
 	stream, err := client.EngineLog(ctx, &rpc.LogRequest{
 		Name: volumeName,
 	})
@@ -220,7 +217,7 @@ func (cli *EngineManagerClient) EngineLog(volumeName string) (*api.LogStream, er
 		return nil, fmt.Errorf("failed to get engine log of volume %v: %v", volumeName, err)
 	}
 
-	return api.NewLogStream(stream), nil
+	return api.NewLogStream(conn, cancel, stream), nil
 }
 
 func (cli *EngineManagerClient) FrontendStart(name, frontend string) error {

--- a/client/process_manager.go
+++ b/client/process_manager.go
@@ -145,17 +145,14 @@ func (cli *ProcessManagerClient) ProcessLog(name string) (*api.LogStream, error)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
 	}
-	defer conn.Close()
 
 	client := rpc.NewProcessManagerServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
-	defer cancel()
-
 	stream, err := client.ProcessLog(ctx, &rpc.LogRequest{
 		Name: name,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get process log of %v: %v", name, err)
 	}
-	return api.NewLogStream(stream), nil
+	return api.NewLogStream(conn, cancel, stream), nil
 }


### PR DESCRIPTION
This PR fixes the `gRPC client` implementation of `LogStream` on both `EngineManagerClient` and `ProcessManagerClient` to avoid automatically closing the `Connection` or cancelling the `Context`, leaving it up to the `Client` to manually call the `Close()` method instead. This allows the `Stream` to actually be functional instead of immediately being closed right after its creation.