### PR TITLE
Fix deadlock on surge in Process removals

### DIFF
--- a/process/process_manager.go
+++ b/process/process_manager.go
@@ -264,13 +264,13 @@ func (pm *Manager) unregisterProcess(p *Process) {
 
 	if p.IsStopped() {
 		pm.lock.Lock()
-		defer pm.lock.Unlock()
 		if err := pm.releasePorts(p.PortStart, p.PortEnd); err != nil {
 			logrus.Errorf("Process Manager: cannot deallocate %v ports (%v-%v) for %v: %v",
 				p.PortCount, p.PortStart, p.PortEnd, p.Name, err)
 		}
 		logrus.Infof("Process Manager: successfully unregistered process %v", p.Name)
 		delete(pm.processes, p.Name)
+		pm.lock.Unlock()
 		p.UpdateCh <- p
 	} else {
 		logrus.Errorf("Process Manager: failed to unregister process %v since it is state %v rather than stopped", p.Name, p.State)


### PR DESCRIPTION
This PR fixes a possible deadlock that could occur in the situation of a large surge in `Processes` attempting to be unregistered by the `Instance Manager`. In this situation, the `Process Manager` would attempt to send an update to the `updateCh` before releasing the `Process Manager` lock. However, if a large number of `Processes` attempted this at the same time, another `Process` could hold the lock required for the `updateCh` to finish processing the previous update, causing a deadlock.

The `Process Manager` now immediately releases the `Process Manager` lock once it has been unregistered so that other processes may proceed with doing the same and so the `updateCh` can have a chance at attaining the `Process Manager` lock to continue processing the `Watch` update.