### PR TITLE
process/engine: Fix the deadlock while sending response to channel

### DIFF
--- a/engine/engine_manager.go
+++ b/engine/engine_manager.go
@@ -143,6 +143,7 @@ func (em *Manager) EngineCreate(ctx context.Context, req *rpc.EngineCreateReques
 	if err := em.registerEngineLauncher(el); err != nil {
 		return nil, errors.Wrapf(err, "failed to register engine launcher %v", el.LauncherName)
 	}
+	el.UpdateCh <- el
 	if err := el.createEngineProcess(newEngine, em.listen, em.processManager); err != nil {
 		go em.unregisterEngineLauncher(req.Spec.Name)
 		return nil, errors.Wrapf(err, "failed to start engine %v", req.Spec.Name)
@@ -170,7 +171,6 @@ func (em *Manager) registerEngineLauncher(el *Launcher) error {
 	em.pStreamWrapper.AddLauncherStream(el.pUpdateCh)
 	el.UpdateCh = em.elUpdateCh
 	em.engineLaunchers[el.LauncherName] = el
-	el.UpdateCh <- el
 	return nil
 }
 

--- a/process/process_manager.go
+++ b/process/process_manager.go
@@ -145,7 +145,7 @@ func (pm *Manager) ProcessCreate(ctx context.Context, req *rpc.ProcessCreateRequ
 	if err := pm.registerProcess(p); err != nil {
 		return nil, err
 	}
-
+	p.UpdateCh <- p
 	p.Start()
 
 	return p.RPCResponse(), nil
@@ -204,7 +204,6 @@ func (pm *Manager) registerProcess(p *Process) error {
 
 	p.UpdateCh = pm.processUpdateCh
 	pm.processes[p.Name] = p
-	p.UpdateCh <- p
 
 	return nil
 }

--- a/process/process_test.go
+++ b/process/process_test.go
@@ -52,7 +52,7 @@ func (s *TestSuite) TearDownSuite(c *C) {
 }
 
 func (s *TestSuite) TestCRUD(c *C) {
-	count := 1
+	count := 100
 	wg := &sync.WaitGroup{}
 	pw := &ProcessWatcher{}
 	ctx := context.TODO()


### PR DESCRIPTION
Detected by the process unit test with only two concurrent threads.

Now we can bump up the thread number to 100 for the basic unit test.

Also fix a similar issue of the engine.