### PR TITLE
engine: Remove per launcher monitor

### DIFF
--- a/process/process_manager.go
+++ b/process/process_manager.go
@@ -176,7 +176,7 @@ func (pm *Manager) registerProcess(p *Process) error {
 
 	_, exists := pm.processes[p.Name]
 	if exists {
-		return status.Errorf(codes.AlreadyExists, "engine process %v already exists", p.Name)
+		return status.Errorf(codes.AlreadyExists, "process %v already exists", p.Name)
 	}
 
 	if len(p.PortArgs) > int(p.PortCount) {


### PR DESCRIPTION
Engine manager now maintains a list for the engineName to launcher map.

Previous implementation results only one of the launcher will receive
the notification, as well as left launcher monitoring thread behind.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>