### PR TITLE
build: add package for building docker image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -38,6 +38,22 @@ ENV DOCKER_URL_amd64=https://download.docker.com/linux/ubuntu/dists/bionic/pool/
 
 RUN wget ${!DOCKER_URL} -O docker_ce_${ARCH} && dpkg -i docker_ce_${ARCH}
 
+# Build liblonghorn
+RUN cd /usr/src && \
+    git clone https://github.com/rancher/liblonghorn.git && \
+    cd liblonghorn && \
+    git checkout 6592b9967d1b5acbb51a5596abfe0a0d7bad16dc && \
+    make deb && \
+    dpkg -i ./pkg/liblonghorn_*.deb
+
+# Build TGT
+RUN cd /usr/src && \
+    git clone https://github.com/rancher/tgt.git && \
+    cd tgt && \
+    git checkout e042fdd3616ca90619637b5826695a3de9b5dd8e && \
+    ./scripts/build-pkg.sh deb && \
+    dpkg -i ./pkg/tgt_*.deb
+
 VOLUME /tmp
 ENV TMPDIR /tmp
 ENTRYPOINT ["./scripts/entry"]

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y kmod curl nfs-common fuse \
+        libibverbs1 librdmacm1 libconfig-general-perl libaio1 sg3-utils \
+        iputils-ping telnet iperf qemu-utils wget iproute2
+
+# Install grpc_health_probe
+RUN wget -O /usr/local/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.0/grpc_health_probe-linux-amd64 && \
+    chmod +x /usr/local/bin/grpc_health_probe
+
+COPY bin/longhorn-instance-manager /usr/local/bin/
+
+COPY package/engine-manager /usr/local/bin/
+
+COPY bin/tgt_*.deb /opt/
+
+RUN dpkg -i /opt/tgt_*.deb
+
+VOLUME /usr/local/bin
+
+# Add Tini
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["longhorn"]

--- a/package/engine-manager
+++ b/package/engine-manager
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mount --rbind /host/dev /dev
+
+tgtd -f 2>&1 | tee /var/log/tgtd.log &
+
+exec longhorn-instance-manager "$@"

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,3 +6,4 @@ cd $(dirname $0)
 ./build
 ./validate
 ./test
+./package

--- a/scripts/package
+++ b/scripts/package
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/version
+
+cd $(dirname $0)/..
+
+PROJECT=`basename "$PWD"`
+
+TAG=${TAG:-${VERSION}}
+REPO=${REPO:-longhornio}
+IMAGE=${REPO}/${PROJECT}:${TAG}
+
+if [ ! -x ./bin/longhorn ]; then
+    ./scripts/build
+fi
+
+cp /usr/src/tgt/pkg/tgt_*.deb ./bin/
+
+docker build -t ${IMAGE} -f package/Dockerfile .
+
+echo Built ${IMAGE}
+
+echo ${IMAGE} > ./bin/latest_image


### PR DESCRIPTION
Also build tgtd in the instance manager image because it's the running
environment for the engine.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>