### PR TITLE
package: Set the instance manager image tag to API Version + date

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
-        libconfig-general-perl libaio-dev libc6-dev iptables libltdl7  libdevmapper-dev iproute2
+        libconfig-general-perl libaio-dev libc6-dev iptables libltdl7 libdevmapper-dev iproute2 jq
 
 # needed for ${!var} substitution
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh

--- a/scripts/package
+++ b/scripts/package
@@ -7,13 +7,14 @@ cd $(dirname $0)/..
 
 PROJECT=`basename "$PWD"`
 
-TAG=${TAG:-${VERSION}}
-REPO=${REPO:-longhornio}
-IMAGE=${REPO}/${PROJECT}:${TAG}
-
 if [ ! -x ./bin/longhorn ]; then
     ./scripts/build
 fi
+
+APIVERSION=`./bin/longhorn-instance-manager version --client-only|jq ".clientVersion.instanceManagerAPIVersion"`
+TAG="v${APIVERSION}_`date -u +%Y%m%d`"
+REPO=${REPO:-longhornio}
+IMAGE=${REPO}/${PROJECT}:${TAG}
 
 cp /usr/src/tgt/pkg/tgt_*.deb ./bin/
 


### PR DESCRIPTION
To make it separate from the engine image version.

It looks like: `longhornio/longhorn-instance-manager:v1_20200301`

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>