### PR TITLE
🐛 Utils: make GetURL IPv6 ready

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/satori/go.uuid"
@@ -67,7 +69,7 @@ func PrintJSON(obj interface{}) error {
 }
 
 func GetURL(host string, port int) string {
-	return fmt.Sprintf("%s:%d", host, port)
+	return net.JoinHostPort(host, strconv.Itoa(port))
 }
 
 func RemoveFile(file string) error {


### PR DESCRIPTION
Hi,
Another small MR to make `GetURL` IPv6 ready for IPv6-only cluster. This function is actually used by the `longhorn-manager` code

Once this MR is merged, I'll be able to make another one in longhorn-manager (https://github.com/Frankkkkk/longhorn-manager/commit/aaec3d48717247e8b28e1e2a51f9aa313f5122ee , still WIP)


Related to https://github.com/longhorn/longhorn-manager/pull/663 and https://github.com/longhorn/longhorn-ui/pull/320

Cheers !