### PR TITLE
IM Deadlock fixes - part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 *.so
 *.dylib
 
+# Editors
+.idea
+.vscode
+
 # Test binary, build with `go test -c`
 *.test
 

--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -468,7 +468,7 @@ func (pm *Manager) initProcessReplace(p *Process) (*Process, error) {
 
 	oldProcess, exists := pm.processes[p.Name]
 	if !exists {
-		return nil, status.Errorf(codes.AlreadyExists, "process %v doesn't exists", p.Name)
+		return nil, status.Errorf(codes.NotFound, "existing process %v doesn't exists", p.Name)
 	}
 
 	if err := pm.allocateProcessPorts(p); err != nil {

--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -443,7 +443,6 @@ func (pm *Manager) ProcessReplace(ctx context.Context, req *rpc.ProcessReplaceRe
 	pm.releaseProcessPorts(oldProcess)
 	logrus.Infof("Process Manager: successfully unregistered old process %v", p.Name)
 
-	p.UpdateCh = pm.processUpdateCh
 	pm.processes[p.Name] = p
 	logrus.Infof("Process Manager: successfully registered new process %v", p.Name)
 
@@ -463,7 +462,12 @@ func (pm *Manager) initProcessReplace(p *Process) error {
 		return status.Errorf(codes.AlreadyExists, "process %v doesn't exists", p.Name)
 	}
 
-	return pm.allocateProcessPorts(p)
+	if err := pm.allocateProcessPorts(p); err != nil {
+		return err
+	}
+
+	p.UpdateCh = pm.processUpdateCh
+	return nil
 }
 
 func (pm *Manager) allocateProcessPorts(p *Process) error {


### PR DESCRIPTION
This contains: 
- 1 data race
there was a race in the process UpdateChannel assignment

- 1 deadlock fix
the above race leads to a deadlock when the binary couldn't be located.

- 1 nil pointer fix:
there was a nil pointer case, while updating a process that is being
deleted, since when initially checked the process was still in the map
but by the time new process has started the old process had been removed

There will be a **part two that fixes another deadlock issue** as well as adds unit tests for all these cases.
Since the builds would potentially deadlock, I decided to split the PR up till the fix for the final deadlock issue is available.

The explanation for the second deadlock is below, this one could be quite common during parallel engine upgrades for example:
// there was a deadlock when the im.monitor is processing an element
// from the updateChannel, it will try to RLock, to evaluate the existing
// processes. This will deadlock, if during that time a process is
// being replaced, since as part of the replacement. The old process
// when being stopped will try to sent the updated process on the update channel
// while the other scope has acquired a WriteLock.
// Since the IM is waiting on the ReadLock acquisition, while inside of the channel receive
// this will be a total deadlock, since the channel receive can never finish therefore all
// additional sents will be blocked.
// https://github.com/longhorn/longhorn/issues/2697


For the unit tests with a description of each dead lock, have a look here:
https://github.com/joshimoo/longhorn-instance-manager/commit/de3bafdb037aa7c025352a50f5debf8e4ae7aaa3


longhorn/longhorn#2697