### PR TITLE
update Dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,12 +1,15 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG ARCH=amd64
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
-    apt-get upgrade -y && \
+    apt-get dist-upgrade -y && \
     apt-get install -y kmod curl nfs-common fuse \
     libibverbs1 librdmacm1 libconfig-general-perl libaio1 sg3-utils \
-    iputils-ping telnet iperf qemu-utils wget iproute2
+    iputils-ping telnet iperf qemu-utils wget iproute2 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install grpc_health_probe
 RUN wget https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.2/grpc_health_probe-linux-${ARCH} -O /usr/local/bin/grpc_health_probe && \


### PR DESCRIPTION
- Use Ubuntu 20.04 as base image
- Use `apt-get dist-upgrade` instead of `apt-get upgrade`
- add `DEBIAN_FRONTEND=noninteractive` env variable, to skip `tzdata` interactive configuration. 

```
       upgrade
           upgrade is used to install the newest versions of all packages
           currently installed on the system from the sources enumerated in
           /etc/apt/sources.list. Packages currently installed with new
           versions available are retrieved and upgraded; under no
           circumstances are currently installed packages removed, or packages
           not already installed retrieved and installed. New versions of
           currently installed packages that cannot be upgraded without
           changing the install status of another package will be left at
           their current version. An update must be performed first so that
           apt-get knows that new versions of packages are available.

       dist-upgrade
           dist-upgrade in addition to performing the function of upgrade,
           also intelligently handles changing dependencies with new versions
           of packages; apt-get has a "smart" conflict resolution system, and
           it will attempt to upgrade the most important packages at the
           expense of less important ones if necessary. The dist-upgrade
           command may therefore remove some packages. The
           /etc/apt/sources.list file contains a list of locations from which
           to retrieve desired package files. See also apt_preferences(5) for
           a mechanism for overriding the general settings for individual
```

Signed-off-by: Mohamed Eldafrawi <mohamed.eldafrawi@suse.com>