### PR TITLE
Fix grpc client connection leak (VersionGet, ProcessLog, ProcessWatch)

### DIFF
--- a/pkg/client/process_manager.go
+++ b/pkg/client/process_manager.go
@@ -125,13 +125,21 @@ func (cli *ProcessManagerClient) ProcessLog(name string) (*api.LogStream, error)
 		return nil, fmt.Errorf("failed to get process: missing required parameter name")
 	}
 
+	var err error
 	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
 	}
 
-	client := rpc.NewProcessManagerServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)
+	defer func() {
+		if err != nil {
+			cancel()
+			conn.Close()
+		}
+	}()
+
+	client := rpc.NewProcessManagerServiceClient(conn)
 	stream, err := client.ProcessLog(ctx, &rpc.LogRequest{
 		Name: name,
 	})
@@ -142,15 +150,23 @@ func (cli *ProcessManagerClient) ProcessLog(name string) (*api.LogStream, error)
 }
 
 func (cli *ProcessManagerClient) ProcessWatch() (*api.ProcessStream, error) {
+	var err error
 	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer func() {
+		if err != nil {
+			cancel()
+			conn.Close()
+		}
+	}()
+
 	// Don't cleanup the Client here, we don't know when the user will be done with the Stream. Pass it to the wrapper
 	// and allow the user to take care of it.
 	client := rpc.NewProcessManagerServiceClient(conn)
-	ctx, cancel := context.WithCancel(context.Background())
 	stream, err := client.ProcessWatch(ctx, &empty.Empty{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open process update stream")
@@ -198,6 +214,7 @@ func (cli *ProcessManagerClient) VersionGet() (*meta.VersionOutput, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect process manager service to %v: %v", cli.Address, err)
 	}
+	defer conn.Close()
 
 	client := rpc.NewProcessManagerServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), types.GRPCServiceTimeout)


### PR DESCRIPTION
- the VersionGet grpc connection is always leaked
- the streaming grpc connections are leaked in the call error case

I saw this and decided to fix it quickly while I was looking into something else.

longhorn/longhorn#2824