### PR TITLE
Fix U1000 errors

### DIFF
--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -38,9 +38,6 @@ type TestSuite struct {
 
 var _ = Suite(&TestSuite{})
 
-func generateUUID() string {
-	return uuid.NewV4().String()
-}
 
 type ProcessWatcher struct {
 	grpc.ServerStream

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -19,7 +19,6 @@ type LonghornFormatter struct {
 
 	LogsDir string
 
-	logFiles []*os.File
 }
 
 type LonghornWriter struct {


### PR DESCRIPTION
Signed-off-by: Shatakshi <shatakshi.gupta85@gmail.com>
Related to Bugbash. Fixes U1000 errors as reported by [Sonatype Lift](https://lift.sonatype.com/result/longhorn/longhorn-instance-manager/01FHW2G28KAZ4H2C925W1JYESA?t=CustomTool%20%22Staticcheck%22%7CU1000).