### PR TITLE
Fix bugbash errors

### DIFF
--- a/pkg/client/process_manager.go
+++ b/pkg/client/process_manager.go
@@ -180,7 +180,7 @@ func (cli *ProcessManagerClient) ProcessReplace(name, binary string, portCount i
 		return nil, fmt.Errorf("failed to start process: missing required parameter")
 	}
 	if terminateSignal != "SIGHUP" {
-		return nil, fmt.Errorf("Unsupported terminate signal %v", terminateSignal)
+		return nil, fmt.Errorf("unsupported terminate signal %v", terminateSignal)
 	}
 
 	conn, err := grpc.Dial(cli.Address, grpc.WithInsecure())

--- a/pkg/health/health_probe.go
+++ b/pkg/health/health_probe.go
@@ -30,7 +30,7 @@ func (hc *CheckServer) Check(context.Context, *healthpb.HealthCheckRequest) (*he
 
 	return &healthpb.HealthCheckResponse{
 		Status: healthpb.HealthCheckResponse_NOT_SERVING,
-	}, fmt.Errorf("Engine Manager or Process Manager or Instance Manager is not running")
+	}, fmt.Errorf("engine Manager or process Manager or instance Manager is not running")
 }
 
 func (hc *CheckServer) Watch(req *healthpb.HealthCheckRequest, ws healthpb.Health_WatchServer) error {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -101,7 +101,6 @@ func (p *Process) Start() error {
 			p.lock.Unlock()
 			p.UpdateCh <- p
 		}
-		return
 	}()
 
 	return nil

--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -352,19 +352,19 @@ func (pm *Manager) releasePorts(start, end int32) error {
 
 func ParsePortRange(portRange string) (int32, int32, error) {
 	if portRange == "" {
-		return 0, 0, fmt.Errorf("Empty port range")
+		return 0, 0, fmt.Errorf("empty port range")
 	}
 	parts := strings.Split(portRange, "-")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("Invalid format for range: %s", portRange)
+		return 0, 0, fmt.Errorf("invalid format for range: %s", portRange)
 	}
 	portStart, err := strconv.Atoi(strings.TrimSpace(parts[0]))
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid start port for range: %s", err)
+		return 0, 0, fmt.Errorf("invalid start port for range: %s", err)
 	}
 	portEnd, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 	if err != nil {
-		return 0, 0, fmt.Errorf("Invalid end port for range: %s", err)
+		return 0, 0, fmt.Errorf("invalid end port for range: %s", err)
 	}
 	return int32(portStart), int32(portEnd), nil
 }

--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -238,7 +238,6 @@ func (pm *Manager) unregisterProcess(p *Process) {
 		p.UpdateCh <- p
 	}()
 
-	return
 }
 
 func (pm *Manager) findProcess(name string) *Process {

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -38,9 +38,6 @@ type TestSuite struct {
 
 var _ = Suite(&TestSuite{})
 
-func generateUUID() string {
-	return uuid.NewV4().String()
-}
 
 type ProcessWatcher struct {
 	grpc.ServerStream

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -19,7 +19,6 @@ type LonghornFormatter struct {
 
 	LogsDir string
 
-	logFiles []*os.File
 }
 
 type LonghornWriter struct {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -47,12 +47,12 @@ func ExecuteWithTimeout(timeout time.Duration, binary string, args ...string) (s
 			}
 
 		}
-		return "", fmt.Errorf("Timeout executing: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("timeout executing: %v %v, output %s, stderr, %s, error %v",
 			binary, args, output.String(), stderr.String(), err)
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("Failed to execute: %v %v, output %s, stderr, %s, error %v",
+		return "", fmt.Errorf("failed to execute: %v %v, output %s, stderr, %s, error %v",
 			binary, args, output.String(), stderr.String(), err)
 	}
 	return output.String(), nil


### PR DESCRIPTION
Related to Bugbash. This PR fixes return keyword errors, string statements errors and unused function errors as reported by Sonatype Lift [here](https://lift.sonatype.com/result/longhorn/longhorn-instance-manager/01FHW2G28KAZ4H2C925W1JYESA?t=CustomTool%20%22Staticcheck%22%7CST1005&t=CustomTool%20%22Staticcheck%22%7CS1023&t=CustomTool%20%22Staticcheck%22%7CU1000).