### PR TITLE
Fix Bugbash errors

### DIFF
--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -87,7 +87,6 @@ func (pm *Manager) startMonitoring() {
 		case <-pm.shutdownCh:
 			logrus.Infof("Process Manager is shutting down")
 			done = true
-			break
 		case p := <-pm.processUpdateCh:
 			resp := p.RPCResponse()
 			pm.lock.RLock()

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -38,9 +38,6 @@ type TestSuite struct {
 
 var _ = Suite(&TestSuite{})
 
-func generateUUID() string {
-	return uuid.NewV4().String()
-}
 
 type ProcessWatcher struct {
 	grpc.ServerStream

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -19,7 +19,6 @@ type LonghornFormatter struct {
 
 	LogsDir string
 
-	logFiles []*os.File
 }
 
 type LonghornWriter struct {
@@ -34,7 +33,7 @@ func NewLonghornWriter(name string, logsDir string) (*LonghornWriter, error) {
 	if err != nil {
 		return nil, err
 	}
-	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +45,7 @@ func NewLonghornWriter(name string, logsDir string) (*LonghornWriter, error) {
 }
 
 func SetUpLogger(logsDir string) error {
-	if err := os.MkdirAll(logsDir, 0755); err != nil {
+	if err := os.MkdirAll(logsDir, 0750); err != nil {
 		return err
 	}
 	logsDir, err := filepath.Abs(logsDir)
@@ -54,7 +53,7 @@ func SetUpLogger(logsDir string) error {
 		return err
 	}
 	testFile := filepath.Join(logsDir, "test")
-	if _, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0644); os.IsPermission(err) {
+	if _, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0600); os.IsPermission(err) {
 		return err
 	}
 	logrus.Infof("Storing process logs at path: %v", logsDir)
@@ -99,7 +98,7 @@ func (l LonghornWriter) Close() error {
 }
 
 func (l LonghornWriter) StreamLog(done chan struct{}) (chan string, error) {
-	file, err := os.OpenFile(l.path, os.O_RDONLY, 0644)
+	file, err := os.OpenFile(l.path, os.O_RDONLY, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Shatakshi <shatakshi.gupta85@gmail.com>
This PR fixes errors as show by [Sonatype Lift](https://lift.sonatype.com/result/longhorn/longhorn-instance-manager/01FHW2G28KAZ4H2C925W1JYESA?t=CustomTool%20%22golangci-lint%22%7Cdeadcode&t=CustomTool%20%22Staticcheck%22%7CSA4011&t=CustomTool%20%22golangci-lint%22%7Cstructcheck&t=CustomTool%20%22GoSec%22%7CG302&t=CustomTool%20%22GoSec%22%7CG301) for GoSec, staticcheck and golangci-lint.