### PR TITLE
fix cli im client non tls fallback

### DIFF
--- a/app/cmd/process.go
+++ b/app/cmd/process.go
@@ -202,11 +202,15 @@ func getProcessManagerClient(c *cli.Context) (*client.ProcessManagerClient, erro
 	tlsDir := c.GlobalString("tls-dir")
 
 	if tlsDir != "" {
-		return client.NewProcessManagerClientWithTLS(url,
+		imClient, err := client.NewProcessManagerClientWithTLS(url,
 			filepath.Join(tlsDir, "ca.crt"),
 			filepath.Join(tlsDir, "tls.crt"),
 			filepath.Join(tlsDir, "tls.key"),
 			"longhorn-backend.longhorn-system")
+		if err == nil {
+			return imClient, err
+		}
+		logrus.WithError(err).Info("Falling back to non tls client")
 	}
 
 	return client.NewProcessManagerClient(url, nil)

--- a/app/cmd/start.go
+++ b/app/cmd/start.go
@@ -29,7 +29,8 @@ func StartCmd() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:  "listen",
-				Value: "localhost:8500",
+				Value: "tcp://localhost:8500",
+				Usage: "specifies the server endpoint to listen on supported protocols are 'tcp' and 'unix'",
 			},
 			cli.StringFlag{
 				Name:  "logs-dir",
@@ -113,7 +114,7 @@ func start(c *cli.Context) error {
 		logrus.Info("Creating grpc server with no auth")
 	}
 
-	rpcService, listenAt, err := util.NewServer("tcp://"+listen, tlsConfig,
+	rpcService, listenAt, err := util.NewServer(listen, tlsConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,

--- a/main.go
+++ b/main.go
@@ -34,7 +34,8 @@ func main() {
 	a.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "url",
-			Value: "localhost:8500",
+			Value: "tcp://localhost:8500",
+			Usage: "specifies the server endpoint to connect to supported protocols are 'tcp' and 'unix'",
 		},
 		cli.BoolFlag{
 			Name: "debug",

--- a/pkg/util/grpcutil_test.go
+++ b/pkg/util/grpcutil_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"testing"
+)
+
+func Test_parseEndpoint(t *testing.T) {
+	type args struct {
+		ep string
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantProto   string
+		wantAddress string
+		wantErr     bool
+	}{
+		{name: "testEndpointUnix", args: args{ep: "unix:///tmp/test.sock"}, wantProto: "unix", wantAddress: "/tmp/test.sock", wantErr: false},
+		{name: "testEndpointTcp", args: args{ep: "tcp://127.0.0.1:8500"}, wantProto: "tcp", wantAddress: "127.0.0.1:8500", wantErr: false},
+		{name: "testEndpointProtoMissingFallback", args: args{ep: "localhost:8500"}, wantProto: "tcp", wantAddress: "localhost:8500", wantErr: false},
+		{name: "testEndpointProtoUnsupported", args: args{ep: "unsupported://127.0.0.1:8500"}, wantProto: "", wantAddress: "", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProto, gotAddress, err := parseEndpoint(tt.args.ep)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseEndpoint() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotProto != tt.wantProto {
+				t.Errorf("parseEndpoint() gotProto = %v, want %v", gotProto, tt.wantProto)
+			}
+			if gotAddress != tt.wantAddress {
+				t.Errorf("parseEndpoint() gotAddress = %v, want %v", gotAddress, tt.wantAddress)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- fixed the cli client non tls fallback
- added cli tcp:// to the default endpoint (listen/url)
- fallback to tcp in case endpoint doesn't specify proto (client/server)
- added unit tests for parseEndpoint function

longhorn/longhorn#3966
