### PR TITLE
meta: revert InstanceManagerAPIVersion update

### DIFF
--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -2,7 +2,7 @@ package meta
 
 const (
 	// InstanceManagerAPIVersion used to communicate with the user e.g. longhorn-manager
-	InstanceManagerAPIVersion    = 3
+	InstanceManagerAPIVersion    = 2
 	InstanceManagerAPIMinVersion = 1
 
 	// InstanceManagerProxyAPIVersion is used for compatibility check for longhorn-manager


### PR DESCRIPTION
InstanceManager APIs are not updated, so revert the InstanceManagerAPIVersion update.

longhorn/longhorn#4210
longhorn/longhorn#3198

Signed-off-by: Derek Su <derek.su@suse.com>