### PR TITLE
meta: Bump up the API version by 1

### DIFF
--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -2,7 +2,7 @@ package meta
 
 const (
 	// InstanceManagerAPIVersion used to communicate with the user e.g. longhorn-manager
-	InstanceManagerAPIVersion    = 2
+	InstanceManagerAPIVersion    = 3
 	InstanceManagerAPIMinVersion = 1
 
 	// InstanceManagerProxyAPIVersion is used for compatibility check for longhorn-manager


### PR DESCRIPTION
To distinguish if the instance manager supports online expansion, we have to bump up the API version

Longhorn/longhorn#1674