### PR TITLE
Fix bug: volume is stuck in live engine upgrading

### DIFF
--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -457,6 +457,11 @@ func (pm *Manager) ProcessReplace(ctx context.Context, req *rpc.ProcessReplaceRe
 		return nil, err
 	}
 
+	if processToReplace.Binary == p.Binary {
+		logrus.Infof("Process Manager: the existing process already has the updated engine image %v", p.Binary)
+		return processToReplace.RPCResponse(), nil
+	}
+
 	cleanupReplacementProcess := func() {
 		// TODO process ports should be tied to process UUID's right now only the port ranges is used
 		//  so if one is not careful with allocation/release it's possible that different processes nuke each


### PR DESCRIPTION
The only usecase of ProcessReplace is for engine image live upgrade. If the new engine process has the same binary as the existing engine process, there is no reason to do the ProcessReplace

longhorn/longhorn#5684