### PR TITLE
Error out when continuously receiving errors while watching instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/longhorn/backupstore v0.0.0-20230830075002-fa25b1a97ffd
 	github.com/longhorn/go-spdk-helper v0.0.0-20230802035240-e5fe21b6067f
 	github.com/longhorn/longhorn-engine v1.4.0-rc1.0.20230914160943-b42224518443
-	github.com/longhorn/longhorn-spdk-engine v0.0.0-20230802040621-1fda4c2a0100
+	github.com/longhorn/longhorn-spdk-engine v0.0.0-20230918005703-278e4c64077e
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/urfave/cli v1.22.12

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/longhorn/go-spdk-helper v0.0.0-20230802035240-e5fe21b6067f h1:aVnA0Uf
 github.com/longhorn/go-spdk-helper v0.0.0-20230802035240-e5fe21b6067f/go.mod h1:XoGXOYHw1KW3qdvTSimwY+Anyg5cPl6EVkjXxS25Upg=
 github.com/longhorn/longhorn-engine v1.4.0-rc1.0.20230914160943-b42224518443 h1:4P/dmOAq8nMGg9vnXkT04NBdNidOCPXg2LM3J63ewn8=
 github.com/longhorn/longhorn-engine v1.4.0-rc1.0.20230914160943-b42224518443/go.mod h1:zcfS53mU3LkxWAWf2MkHsa75Q4t01GmiW++mfp1+78M=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20230802040621-1fda4c2a0100 h1:2pY5WHq0n7oZvIqeNftp2kxR/KeRmgx6AeSvT1C7pk0=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20230802040621-1fda4c2a0100/go.mod h1:f8Je075pqXDysiTFaiJ/bapeQoNDsL5KOUixQg7y5tg=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20230918005703-278e4c64077e h1:LDp4dV2vTkjjp/D5LTCgAV90OrWuouYrNw75CHIjLlM=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20230918005703-278e4c64077e/go.mod h1:f8Je075pqXDysiTFaiJ/bapeQoNDsL5KOUixQg7y5tg=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003 h1:Jw9uANsGcHTxp6HcC++/vN17LfeuDmozHI2j6DoZf5E=
 github.com/longhorn/nsfilelock v0.0.0-20200723175406-fa7c83ad0003/go.mod h1:0CLeXlf59Lg6C0kjLSDf47ft73Dh37CwymYRKWwAn04=
 github.com/longhorn/sparse-tools v0.0.0-20230408015858-c849def39d3c h1:EAE/cBOWZUL9CDiI4xbOr1IudQUa2e6u/pdScytEcvo=

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/client/client.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/client/client.go
@@ -24,11 +24,14 @@ type SPDKServiceContext struct {
 	service spdkrpc.SPDKServiceClient
 }
 
-func (c SPDKServiceContext) Close() error {
-	if c.cc == nil {
-		return nil
+func (c *SPDKServiceContext) Close() error {
+	if c.cc != nil {
+		if err := c.cc.Close(); err != nil {
+			return err
+		}
+		c.cc = nil
 	}
-	return c.cc.Close()
+	return nil
 }
 
 func (c *SPDKClient) getSPDKServiceClient() spdkrpc.SPDKServiceClient {

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/server.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/server.go
@@ -360,7 +360,7 @@ func (s *Server) ReplicaWatch(req *empty.Empty, srv spdkrpc.SPDKService_ReplicaW
 			logrus.Info("SPDK service replica watch ended successfully")
 		}
 	}()
-	logrus.Info("Started new SPDK service update watch")
+	logrus.Info("Started new SPDK service replica update watch")
 
 	done := false
 	for {
@@ -635,7 +635,7 @@ func (s *Server) EngineWatch(req *empty.Empty, srv spdkrpc.SPDKService_EngineWat
 			logrus.Info("SPDK service engine watch ended successfully")
 		}
 	}()
-	logrus.Info("Started new SPDK service update watch")
+	logrus.Info("Started new SPDK service engine update watch")
 
 	done := false
 	for {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
 github.com/longhorn/longhorn-engine/pkg/util/disk
 github.com/longhorn/longhorn-engine/proto/ptypes
-# github.com/longhorn/longhorn-spdk-engine v0.0.0-20230802040621-1fda4c2a0100
+# github.com/longhorn/longhorn-spdk-engine v0.0.0-20230918005703-278e4c64077e
 ## explicit; go 1.17
 github.com/longhorn/longhorn-spdk-engine/pkg/api
 github.com/longhorn/longhorn-spdk-engine/pkg/client


### PR DESCRIPTION
During instance watching, errors can happen due to gRPC server and client errors or keepalive errors. Whenever the error count reaches a maximum, error out the instance watch function.

Longhorn/longhorn#6578