### PR TITLE
Dockerfile: avoid symbolic link dereference when copying files

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -106,8 +106,8 @@ COPY --from=builder \
     /usr/local/bin/
 
 COPY --from=builder \
-    /usr/local/nvme/usr/local/lib64/libnvme* \
-    /usr/local/lib64/
+    /usr/local/nvme/usr/local/lib64 \
+    /usr/local/lib64
 
 RUN ldconfig
 


### PR DESCRIPTION
Before the patch
```
instance-manager-a42838bd900481285c46cda090d88447:/ # ls -al /usr/a/lib64/lib64/
total 1532
drwxr-xr-x 2 root root   4096 Nov 24 08:39 .
drwxr-xr-x 3 root root   4096 Nov 24 08:52 ..
-rwxr-xr-x 1 root root  95280 Nov 24 08:11 libnvme-mi.so
-rwxr-xr-x 1 root root  95280 Nov 24 08:11 libnvme-mi.so.1
-rwxr-xr-x 1 root root  95280 Nov 24 08:11 libnvme-mi.so.1.5.0
-rwxr-xr-x 1 root root 418240 Nov 24 08:11 libnvme.so
-rwxr-xr-x 1 root root 418240 Nov 24 08:11 libnvme.so.1
-rwxr-xr-x 1 root root 418240 Nov 24 08:11 libnvme.so.1.5.0
```

After the patch
```
total 520
drwxr-xr-x 1 root root   4096 Nov 24 08:52 .
drwxr-xr-x 1 root root   4096 Nov 23 07:40 ..
lrwxrwxrwx 1 root root     15 Nov 24 08:11 libnvme-mi.so -> libnvme-mi.so.1
lrwxrwxrwx 1 root root     19 Nov 24 08:11 libnvme-mi.so.1 -> libnvme-mi.so.1.5.0
-rwxr-xr-x 1 root root  95280 Nov 24 08:11 libnvme-mi.so.1.5.0
lrwxrwxrwx 1 root root     12 Nov 24 08:11 libnvme.so -> libnvme.so.1
lrwxrwxrwx 1 root root     16 Nov 24 08:11 libnvme.so.1 -> libnvme.so.1.5.0
-rwxr-xr-x 1 root root 418240 Nov 24 08:11 libnvme.so.1.5.0
drwxr-xr-x 2 root root   4096 Nov 24 08:11 pkgconfig
```

Longhorn/longhorn#5911