### PR TITLE
feat: replace golint with golangci-lint

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH}
 # Setup environment
 ENV PATH /go/bin:$PATH
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_ENV TAG REPO
+ENV DAPPER_ENV TAG REPO DRONE_REPO DRONE_PULL_REQUEST DRONE_COMMIT_REF
 ENV DAPPER_OUTPUT bin coverage.out
 ENV DAPPER_RUN_ARGS --privileged --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.venv:exec --tmpfs /go/src/github.com/longhorn/longhorn-engine/integration/.tox:exec -v /dev:/host/dev -v /proc:/host/proc
 ENV DAPPER_SOURCE /go/src/github.com/longhorn/longhorn-instance-manager
@@ -21,28 +21,28 @@ RUN zypper refresh && \
 
 # Install packages
 RUN if [ ${ARCH} == "amd64" ]; then \
-        zypper -n install autoconf libtool libunwind-devel; \
+    zypper -n install autoconf libtool libunwind-devel; \
     fi
 
 RUN zypper -n install cmake wget curl git less file \
-        libglib-2_0-0 libkmod-devel libnl3-devel linux-glibc-devel pkg-config \
-        psmisc tox qemu-tools fuse python3-devel git zlib-devel zlib-devel-static \
-        bash-completion rdma-core-devel libibverbs xsltproc docbook-xsl-stylesheets \
-        perl-Config-General libaio-devel glibc-devel-static glibc-devel iptables libltdl7 libdevmapper1_03 iproute2 jq docker gcc gcc-c++ && \
-        rm -rf /var/cache/zypp/*
+    libglib-2_0-0 libkmod-devel libnl3-devel linux-glibc-devel pkg-config \
+    psmisc tox qemu-tools fuse python3-devel git zlib-devel zlib-devel-static \
+    bash-completion rdma-core-devel libibverbs xsltproc docbook-xsl-stylesheets \
+    perl-Config-General libaio-devel glibc-devel-static glibc-devel iptables libltdl7 libdevmapper1_03 iproute2 jq docker gcc gcc-c++ && \
+    rm -rf /var/cache/zypp/*
 
 # needed for ${!var} substitution
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN if [ ${ARCH} == "s390x" ]; then \
-        ln -s /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc;\
+    ln -s /usr/bin/gcc /usr/bin/s390x-linux-gnu-gcc;\
     fi
 
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm64=arm64 GOLANG_ARCH_s390x=s390x GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.21.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go install golang.org/x/lint/golint@latest
+RUN wget -O - https://storage.googleapis.com/golang/go1.21.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
 # Install libqcow to resolve error:
 #   vendor/github.com/longhorn/longhorn-engine/pkg/qcow/libqcow.go:6:11: fatal error: libqcow.h: No such file or directory

--- a/scripts/validate
+++ b/scripts/validate
@@ -9,12 +9,21 @@ PACKAGES="$(find -name '*.go' | xargs -I{} dirname {} |  cut -f2 -d/ | sort -u |
 
 echo Running: go vet
 go vet ${PACKAGES}
-echo Running: golint
-for i in ${PACKAGES}; do
-    if [ -n "$(golint $i | grep -v 'should have comment.*or be unexported' | tee /dev/stderr)" ]; then
-        failed=true
-    fi
-done
-test -z "$failed"
+
+if [ ! -z "${DRONE_REPO}" ] && [ ! -z "${DRONE_PULL_REQUEST}" ]; then
+	wget https://github.com/$DRONE_REPO/pull/$DRONE_PULL_REQUEST.patch
+	echo "Running: golangci-lint run --new-from-patch=${DRONE_PULL_REQUEST}.patch"
+	golangci-lint run --new-from-patch="${DRONE_PULL_REQUEST}.patch"
+	rm "${DRONE_PULL_REQUEST}.patch"
+elif [ ! -z "${DRONE_COMMIT_REF}" ]; then
+	echo "Running: golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}"
+	golangci-lint run --new-from-rev=${DRONE_COMMIT_REF}
+else
+	git symbolic-ref -q HEAD && REV="origin/HEAD" || REV="HEAD^"
+	headSHA=$(git rev-parse --short=12 ${REV})
+	echo "Running: golangci-lint run --new-from-rev=${headSHA}"
+	golangci-lint run --new-from-rev=${headSHA}
+fi
+
 echo Running: go fmt
 test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"


### PR DESCRIPTION
issue: https://github.com/longhorn/longhorn/issues/7366

Using `golangci-lint run --new-from-rev=` or `golangci-lint run --new-from-patch=` because there are too many warning for current code.

Ref: https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues