### PR TITLE
Fix bug instance manager pod crashed after upgrading engine image

### DIFF
--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -503,8 +503,10 @@ func (pm *Manager) ProcessReplace(ctx context.Context, req *rpc.ProcessReplaceRe
 		PortCount: req.Spec.PortCount,
 		PortArgs:  req.Spec.PortArgs,
 
-		UUID:  util.UUID(),
-		State: StateStarting,
+		UUID: util.UUID(),
+
+		State:      StateStarting,
+		Conditions: make(map[string]bool),
 
 		lock: &sync.RWMutex{},
 


### PR DESCRIPTION
The function ProcessReplace() doesn't initialize the Conditions map which causes the panic "assignment to entry in nil map" when getProcessToUpdateConditions() attempts to add a key to it

We can observe this error log right after the ProcessReplace() finished:
```
[longhorn-instance-manager] time="2024-01-04T06:35:28Z" level=info msg="Process Manager: successfully replaced process longhorn-testvol-jogcok-e-0" func="process.(*Manager).ProcessReplace" file="process_manager.go:583"
[longhorn-instance-manager] time="2024-01-04T06:35:28Z" level=info msg="Process Manager: successfully unregistered process longhorn-testvol-jogcok-r-9b014111" func="process.(*Manager).unregisterProcess.func1" file="process_manager.go:343"
panic: assignment to entry in nil map

goroutine 14 [running]:
github.com/longhorn/longhorn-instance-manager/pkg/process.(*Manager).getProcessToUpdateConditions(0xc00051c008?, 0xc000501cc0?)
	/go/src/github.com/longhorn/longhorn-instance-manager/pkg/process/process_manager.go:163 +0x4a5
github.com/longhorn/longhorn-instance-manager/pkg/process.(*Manager).checkMountPointStatusForEngine(0xc000322800)
	/go/src/github.com/longhorn/longhorn-instance-manager/pkg/process/process_manager.go:147 +0x14a
github.com/longhorn/longhorn-instance-manager/pkg/process.(*Manager).startInstanceConditionCheck(0xc000322800)
	/go/src/github.com/longhorn/longhorn-instance-manager/pkg/process/process_manager.go:130 +0x125
created by github.com/longhorn/longhorn-instance-manager/pkg/process.NewManager in goroutine 1
	/go/src/github.com/longhorn/longhorn-instance-manager/pkg/process/process_manager.go:90 +0x3a5
➜  ~/.kube 
```

So the flow is engine upgrade init -> engine upgrade finish -> checkMountPointStatusForEngine begin -> panic -> instance-manager pod crash -> liveness probe failed -> data mount point is broken -> the test cannot read/read wrong data -> test failed

The fix would be having function ProcessReplace() initialize the Conditions map similar to the way ProcessCreate() does

longhorn/longhorn#7396