### PR TITLE
Don't send on unbuffered channel while holding a lock

### DIFF
--- a/pkg/process/process_manager.go
+++ b/pkg/process/process_manager.go
@@ -140,18 +140,19 @@ func (pm *Manager) checkMountPointStatusForEngine() {
 	if err != nil {
 		logrus.WithError(err).Warn("Failed to get all volume mount points")
 	}
-
-	pm.lock.RLock()
-	defer pm.lock.RUnlock()
-
-	processToUpdate := pm.getProcessToUpdateConditions(volumeMountPointMap)
-	for _, p := range processToUpdate {
+	// Locking is handled inside getProcessesToUpdateConditions.
+	processesToUpdate := pm.getProcessesToUpdateConditions(volumeMountPointMap)
+	for _, p := range processesToUpdate {
 		p.UpdateCh <- p
 	}
 }
 
-func (pm *Manager) getProcessToUpdateConditions(volumeMountPointMap map[string]mount.MountPoint) []*Process {
-	var processToUpdate []*Process
+func (pm *Manager) getProcessesToUpdateConditions(volumeMountPointMap map[string]mount.MountPoint) []*Process {
+	var processesToUpdate []*Process
+
+	pm.lock.RLock()
+	defer pm.lock.RUnlock()
+
 	for _, p := range pm.processes {
 		p.lock.Lock()
 		if isEngineProcess(p) && p.State == StateRunning {
@@ -161,12 +162,12 @@ func (pm *Manager) getProcessToUpdateConditions(volumeMountPointMap map[string]m
 
 			if mp, exists := volumeMountPointMap[volumeNameSHAStr]; exists {
 				p.Conditions[types.EngineConditionFilesystemReadOnly] = util.IsMountPointReadOnly(mp)
-				processToUpdate = append(processToUpdate, p)
+				processesToUpdate = append(processesToUpdate, p)
 			}
 		}
 		p.lock.Unlock()
 	}
-	return processToUpdate
+	return processesToUpdate
 }
 
 func isEngineProcess(p *Process) bool {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

longhorn/longhorn#7919

#### What this PR does / why we need it:

There is a potential deadlock caused by `pm.getProcessesToUpdateConditions`. See the linked issue for details.

We only need the ProcessManager lock while we are iterating through the Process map. We should not continue to hold it while sending on an unbuffered channel.
