### PR TITLE
refactor: remove engine binary path check

### DIFF
--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -286,62 +286,6 @@ func (s *TestSuite) TestProcessReplaceDuringDeletion(c *C) {
 	wg.Wait()
 }
 
-func (s *TestSuite) TestProcessInvalidProcessBinary(c *C) {
-
-	invalidBinaries := []string{
-		"/usr/bin/echo",
-		"/engine-binaries/invalid-binary",
-		"/host/var/lib/longhorn/engine-binaries/invalid-binary",
-		"/host/var/lib/longhorn/../longhorn/engine-binaries//../engine-binaries/valid-image/invalid-binary",
-	}
-	invalidPaths := []string{
-		"longhorn",
-		"/longhorn",
-		"/engine-binaries/invalid/image/longhorn",
-		"/engine-binaries/longhorn", // missing required image folder
-		"/invalid/path/longhorn",
-	}
-	invalidProcess := append(invalidBinaries, invalidPaths...)
-
-	// invalid process creation
-	for i, binary := range invalidProcess {
-		name := "test_invalid_process-" + strconv.Itoa(i)
-		createReq := &rpc.ProcessCreateRequest{
-			Spec: createProcessSpec(name, binary),
-		}
-		createResp, err := s.pm.ProcessCreate(nil, createReq)
-		c.Assert(createResp, IsNil)
-		c.Assert(err, NotNil)
-		c.Assert(status.Code(err), Equals, codes.InvalidArgument)
-	}
-
-	// valid process creation
-	name := "test_valid_process"
-	assertProcessCreation(c, s.pm, name, TestBinary)
-	defer func() {
-		// verify that the original process is not impacted by an invalid process replace call
-		assertProcessDeletion(c, s.pm, name)
-		deleted, err := waitForProcessListState(s.pm, func(processes map[string]*rpc.ProcessResponse) bool {
-			_, exists := processes[name]
-			return !exists
-		})
-		c.Assert(err, IsNil)
-		c.Assert(deleted, Equals, true)
-	}()
-
-	// invalid process replacement
-	for _, binary := range invalidProcess {
-		replaceReq := &rpc.ProcessReplaceRequest{
-			Spec:            createProcessSpec(name, binary),
-			TerminateSignal: "SIGHUP",
-		}
-		rsp, err := s.pm.ProcessReplace(nil, replaceReq)
-		c.Assert(rsp, IsNil)
-		c.Assert(err, NotNil)
-		c.Assert(status.Code(err), Equals, codes.InvalidArgument)
-	}
-}
-
 func assertProcessReplace(c *C, pm *Manager, name, binary string) {
 	replaceReq := &rpc.ProcessReplaceRequest{
 		Spec:            createProcessSpec(name, binary),


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/8094

The original check limit the pattern of the engine binary path.
But there is no need to check the engine binary path.
Even the path is wrong, we catch the error and show the error message.