### PR TITLE
ci: remove installing make in building arm64 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install make
-      run: sudo apt-get install make
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
     - name: Set up Docker Buildx


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/8039

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
