### PR TITLE
feat(docker-volume): remove volume from dockerfile, no compliant with CIS benchmark

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -145,8 +145,6 @@ COPY package/instance-manager /usr/local/bin/
 # Verify the dependencies for the binaries
 RUN ldd /usr/local/bin/* /usr/local/sbin/* /usr/sbin/* | grep "not found" && exit 1 || true
 
-VOLUME /usr/local/bin
-
 # Add Tini
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini


### PR DESCRIPTION

#### Which issue(s) this PR fixes:

[Issue#8780](https://github.com/longhorn/longhorn/issues/8780)

Related PR on longhorn-manager : [Issue#2893](https://github.com/longhorn/longhorn-manager/pull/2893)
#### What this PR does / why we need it:

This remove volume /usr/local/bin define in dockerfile. In my case, longhorn-manager gets the permission denied error because the noexec option is propagated to the container automatically. in fact, my /var/ volume, used by containerd, has noexec option, with this option longhorn-manager is not allow to start because this option not allow the execution of executable binaries in the mounted filesystem

#### Special notes for your reviewer:

is this volume really used ?

#### Additional documentation or context
