### PR TITLE
Dockerfile: add procps package for missing ps utility

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -106,7 +106,7 @@ RUN zypper -n addrepo --refresh https://download.opensuse.org/repositories/syste
     zypper --gpg-auto-import-keys ref
 
 RUN zypper -n install nfs-client nfs4-acl-tools cifs-utils sg3_utils \
-    iproute2 qemu-tools e2fsprogs xfsprogs util-linux-systemd python3-pyelftools libcmocka-devel device-mapper netcat kmod jq util-linux && \
+    iproute2 qemu-tools e2fsprogs xfsprogs util-linux-systemd python3-pyelftools libcmocka-devel device-mapper netcat kmod jq util-linux procps && \
     rm -rf /var/cache/zypp/*
 
 # Install SPDK dependencies


### PR DESCRIPTION
The instance-manager pod for V2 volume is being terminated due to a failed liveness probe in https://github.com/longhorn/longhorn-manager/blob/master/controller/instance_manager_controller.go#L1314-L1315.
```
		processProbe := "[ $(ps aux | grep 'spdk_tgt' | grep -v 'grep' | grep -v 'tee' | wc -l) != 0 ]"
		livenessProbes = append(livenessProbes, processProbe)
```

This failure is caused by the removal of the ps utility (procps package) in the recent BCI 15.5 and 15.6 images.

Longhorn 8807

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
