### PR TITLE
fix(snapshot): time fallback over creation time

### DIFF
--- a/pkg/proxy/snapshot.go
+++ b/pkg/proxy/snapshot.go
@@ -148,13 +148,21 @@ func (ops V2DataEngineProxyOps) SnapshotList(ctx context.Context, req *rpc.Proxy
 		Disks: map[string]*rpc.EngineSnapshotDiskInfo{},
 	}
 	for snapshotName, snapshot := range disks {
+		/*
+		 * If the snapshot was created before the introduction of the new attribute SnapshotTimestamp,
+		 * and so this one is not available, do fallback over the old one CreationTime.
+		 */
+		snapshotTime := snapshot.SnapshotTimestamp
+		if snapshotTime == "" {
+			snapshotTime = snapshot.CreationTime
+		}
 		resp.Disks[snapshotName] = &rpc.EngineSnapshotDiskInfo{
 			Name:        snapshot.Name,
 			Parent:      snapshot.Parent,
 			Children:    snapshot.Children,
 			Removed:     false,
 			UserCreated: snapshot.UserCreated,
-			Created:     snapshot.SnapshotTimestamp,
+			Created:     snapshotTime,
 			Size:        strconv.FormatUint(snapshot.ActualSize, 10),
 			Labels:      map[string]string{},
 		}


### PR DESCRIPTION
Handling snapshot timestamp for its creation time, if a snapshot has been created before the introduction of the new attribute SnapshotTimestamp, do fallback over ther old one CreationTime. This fix the commit 5af4f97.

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #9045

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
