### PR TITLE
fix: skip updating backup status when it is completed or failed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/longhorn/backupstore v0.0.0-20240827054225-fe89e488b75f
 	github.com/longhorn/go-common-libs v0.0.0-20240821134112-907f57efd48f
 	github.com/longhorn/go-spdk-helper v0.0.0-20240902084253-ba8761258885
-	github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240831055950-b629ebaafa55
+	github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f
 	github.com/longhorn/longhorn-spdk-engine v0.0.0-20240903022243-ca0b8f4dae1f
 	github.com/longhorn/types v0.0.0-20240827042720-af8f10eb57cd
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/longhorn/go-iscsi-helper v0.0.0-20240811043302-df8de353dd58 h1:fzLAnC
 github.com/longhorn/go-iscsi-helper v0.0.0-20240811043302-df8de353dd58/go.mod h1:TobRDCXmF0Ni+jz6+nLJamw3uVu+gNDZoZre1JczGwc=
 github.com/longhorn/go-spdk-helper v0.0.0-20240902084253-ba8761258885 h1:T0IQ9TIVDBm3IYy7ufvxBclxVa4q4c69HgjP0/OlnhY=
 github.com/longhorn/go-spdk-helper v0.0.0-20240902084253-ba8761258885/go.mod h1:hoJmEzRBENFMEPqdX7jiEyjWMYMXNDxEXrHfAE99qVg=
-github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240831055950-b629ebaafa55 h1:BJb3yRM/iCkwaHF8MrIqMCgXkEkiprshivAXBN36NlI=
-github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240831055950-b629ebaafa55/go.mod h1:WxnRZefYEMqrTn4H189DTqIPeKEAknNlmQjoAOk9K38=
+github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f h1:d6UjaruyQFXMoCPYmcf9SfP1svCokONAHblpjJ6XXcc=
+github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f/go.mod h1:WxnRZefYEMqrTn4H189DTqIPeKEAknNlmQjoAOk9K38=
 github.com/longhorn/longhorn-spdk-engine v0.0.0-20240903022243-ca0b8f4dae1f h1:nLZMHdwzwkWeLVXPEw8/JfAaC4ytkgCphnPHNWd/byo=
 github.com/longhorn/longhorn-spdk-engine v0.0.0-20240903022243-ca0b8f4dae1f/go.mod h1:ZJSMYDAwnL2YXDbc9waUi7TY1iAWOy4b8m0edjQM+U0=
 github.com/longhorn/sparse-tools v0.0.0-20240729132735-18b207e459ff h1:gmdQDbnaGJ/zmrK+QJzSys8mH679os6i7vW/pOpRn1U=

--- a/vendor/github.com/longhorn/longhorn-engine/pkg/replica/backup.go
+++ b/vendor/github.com/longhorn/longhorn-engine/pkg/replica/backup.go
@@ -57,6 +57,11 @@ func (rb *BackupStatus) UpdateBackupStatus(snapID, volumeID string, state string
 		return fmt.Errorf("invalid volume [%s] and snapshot [%s], not volume [%s], snapshot [%s]", rb.volumeID, rb.SnapshotID, volumeID, id)
 	}
 
+	if rb.State == ProgressStateComplete || rb.State == ProgressStateError {
+		logrus.Warnf("backup of volume [%s] and snapshot [%s] already completed or failed, skip the status update", rb.volumeID, rb.SnapshotID)
+		return nil
+	}
+
 	rb.State = ProgressState(state)
 	rb.Progress = progress
 	rb.BackupURL = url

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,7 +254,7 @@ github.com/longhorn/go-spdk-helper/pkg/spdk/setup
 github.com/longhorn/go-spdk-helper/pkg/spdk/types
 github.com/longhorn/go-spdk-helper/pkg/types
 github.com/longhorn/go-spdk-helper/pkg/util
-# github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240831055950-b629ebaafa55
+# github.com/longhorn/longhorn-engine v1.8.0-dev-20240825.0.20240905075622-ecfa3c2bc26f
 ## explicit; go 1.22.2
 github.com/longhorn/longhorn-engine/pkg/backingfile
 github.com/longhorn/longhorn-engine/pkg/controller/client


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9168

To prevent race conditions where some goroutines might update the status to 'In Progress' after the backup has already completed or failed, we should skip updating the status in such cases.