### PR TITLE
Fix Dockerfile CMD to correct instance manager binary name.

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -177,4 +177,4 @@ ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARC
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["longhorn"]
+CMD ["longhorn-instance-manager"]


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
None.
Considering the `longhorn-instance-manager` executable requires at least some arguments to it so everyone who's ever used this image overrode `CMD`, this is not really an issue in practice, it's only incorrect if you pass no arguments.

#### What this PR does / why we need it:

Because the current `CMD` arg which gets passed to `tini` doesn't exist, leading to this error if you run the image plainly:

```bash
$ docker run -it longhornio/longhorn-instance-manager:v1.7.0
[FATAL tini (7)] exec longhorn failed: No such file or directory
```

#### Special notes for your reviewer:

Binary built as [`longhorn-instance-manager` here](https://github.com/longhorn/longhorn-instance-manager/blob/master/scripts/build#L22).

Binary [added to Docker image under the same `longhorn-instance-manager` name here](https://github.com/longhorn/longhorn-instance-manager/blob/master/package/Dockerfile#L168).

I am 95% sure the cause of this is someone just copy-pasting [the Engine Dockerfile](https://github.com/longhorn/longhorn-engine/blob/master/package/Dockerfile#L73), whose [binary is indeed plainly named `longhorn`](https://github.com/longhorn/longhorn-engine/blob/master/scripts/build#L22).

#### Additional documentation or context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the container's startup command to launch the `longhorn-instance-manager`, enhancing functionality.

- **Bug Fixes**
	- Streamlined the installation process for development tools and dependencies, improving build reliability.

- **Chores**
	- Refined the build process for various components, ensuring all necessary binaries are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->