### PR TITLE
fix(cpu): high CPU usage of instance-manager pod caused by for tight loops

### DIFF
--- a/pkg/disk/disk.go
+++ b/pkg/disk/disk.go
@@ -84,18 +84,8 @@ func NewServer(ctx context.Context, spdkEnabled bool, spdkServiceAddress string)
 }
 
 func (s *Server) startMonitoring() {
-	done := false
-	for {
-		select {
-		case <-s.ctx.Done():
-			logrus.Infof("%s: stopped monitoring replicas due to the context done", types.DiskGrpcService)
-			done = true
-		default:
-		}
-		if done {
-			break
-		}
-	}
+	<-s.ctx.Done()
+	logrus.Infof("%s: stopped monitoring replicas due to the context done", types.DiskGrpcService)
 }
 
 func (s *Server) VersionGet(ctx context.Context, req *emptypb.Empty) (*rpc.DiskVersionResponse, error) {

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -77,18 +77,8 @@ func NewServer(ctx context.Context, logsDir, processManagerServiceAddress, spdkS
 }
 
 func (s *Server) startMonitoring() {
-	done := false
-	for {
-		select {
-		case <-s.ctx.Done():
-			logrus.Infof("%s: stopped monitoring replicas due to the context done", types.InstanceGrpcService)
-			done = true
-		default:
-		}
-		if done {
-			break
-		}
-	}
+	<-s.ctx.Done()
+	logrus.Infof("%s: stopped monitoring replicas due to the context done", types.InstanceGrpcService)
 }
 
 func (s *Server) VersionGet(ctx context.Context, req *emptypb.Empty) (*rpc.VersionResponse, error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -79,18 +79,8 @@ func NewProxy(ctx context.Context, logsDir, diskServiceAddress, spdkServiceAddre
 }
 
 func (p *Proxy) startMonitoring() {
-	done := false
-	for {
-		select {
-		case <-p.ctx.Done():
-			logrus.Infof("%s: stopped monitoring replicas due to the context done", types.ProxyGRPCService)
-			done = true
-		default:
-		}
-		if done {
-			break
-		}
-	}
+	<-p.ctx.Done()
+	logrus.Infof("%s: stopped monitoring replicas due to the context done", types.ProxyGRPCService)
 }
 
 func (p *Proxy) ServerVersionGet(ctx context.Context, req *rpc.ProxyEngineRequest) (resp *rpc.EngineVersionProxyResponse, err error) {


### PR DESCRIPTION
longhorn/longhorn#9438

Explanation https://github.com/longhorn/longhorn/issues/9438#issuecomment-2347381660

