### PR TITLE
chore(Dockerfile): update go-spdk-helper version

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -17,7 +17,7 @@ RUN go install golang.org/x/lint/golint@latest
 
 # Build go-spdk-helper
 ENV GO_SPDK_HELPER_DIR /usr/src/go-spdk-helper
-ENV GO_SPDK_HELPER_COMMIT_ID f0c0c2a62a57d4dfec80a8928ef3dd3bc70bf6a7
+ENV GO_SPDK_HELPER_COMMIT_ID 6187c63541294a2fa0d792c766ce905d23dac1df
 RUN git clone https://github.com/longhorn/go-spdk-helper.git ${GO_SPDK_HELPER_DIR} && \
     cd ${GO_SPDK_HELPER_DIR} && \
     git checkout ${GO_SPDK_HELPER_COMMIT_ID} && \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/9922

#### What this PR does / why we need it:
Update `package/Dockerfile` to have `go-spdk-helper` updated with lvol detach functionality.

#### Special notes for your reviewer:

#### Additional documentation or context
