### PR TITLE
fix: skip writing zero when dumping data to backing image lvol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/longhorn/go-common-libs v0.0.0-20250107022351-ec79818ce8db
 	github.com/longhorn/go-spdk-helper v0.0.0-20241227145830-6187c6354129
 	github.com/longhorn/longhorn-engine v1.8.0-rc2
-	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250109065136-562df2f4642b
+	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250113052932-5bd1d71da7b6
 	github.com/longhorn/types v0.0.0-20241225162202-00d3a5fd7502
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/longhorn/go-spdk-helper v0.0.0-20241227145830-6187c6354129 h1:yPsm0Lu
 github.com/longhorn/go-spdk-helper v0.0.0-20241227145830-6187c6354129/go.mod h1:gt5O4pBZlkrrQrsEpli+1d6g43clsuMaF/NIhOQ3Oyo=
 github.com/longhorn/longhorn-engine v1.8.0-rc2 h1:soxUV9DAsBtwD2Y+8Za/dLhuBvmxeswec3YIgevYYKc=
 github.com/longhorn/longhorn-engine v1.8.0-rc2/go.mod h1:1Fz703NPKp6OfblSb9YFOWcsGtba0Lj2K0kAZxukssM=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250109065136-562df2f4642b h1:t+PISVMOYnDd+SU4LMYvckBipxw46Saveu4I2OLx6Fw=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250109065136-562df2f4642b/go.mod h1:yyAjiiOcZIeCcBmVsXncWTerh9URLcHY4zgP4fMSCyI=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250113052932-5bd1d71da7b6 h1:Yhbh0ljkZ1VYMD6u7eAik2Rj9LnKeBgmqXKGEBtgwwE=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250113052932-5bd1d71da7b6/go.mod h1:Z/ws+LEmxusbxmvVUwubHlOjKacAP699oha7SnnvwCs=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c h1:OFz3haCSPdgiiJvXLBeId/4dPu0dxIEqkQkfNMufLwc=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c/go.mod h1:dfbJqfI8+T9ZCp5zhTYcBi/64hPBNt5/vFF3gTlfMmc=
 github.com/longhorn/types v0.0.0-20241225162202-00d3a5fd7502 h1:jgw7nosooLe1NQEdCGzM/nEOFzPcurNO+0PDsicc5+A=

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/backing_image.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/backing_image.go
@@ -730,7 +730,7 @@ func (bi *BackingImage) prepareFromSync(targetFh *os.File, fromAddress, srcLvsUU
 
 	ctx, cancel := context.WithCancel(bi.ctx)
 	defer cancel()
-	_, err = util.IdleTimeoutCopy(ctx, cancel, srcFh, targetFh, bi, true)
+	_, err = util.IdleTimeoutCopy(ctx, cancel, srcFh, targetFh, bi, false)
 	if err != nil {
 		return errors.Wrapf(err, "failed to copy the source backing image %v in lvsUUID %v with address %v", bi.Name, srcLvsUUID, exposedSnapshotLvolAddress)
 	}

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/util/http_handler.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/util/http_handler.go
@@ -82,7 +82,7 @@ func (h *HTTPHandler) DownloadFromURL(ctx context.Context, url string, outFh *os
 		return 0, fmt.Errorf("expected status code 200 from %s, got %s", url, resp.Status)
 	}
 
-	copied, err := IdleTimeoutCopy(ctx, cancel, resp.Body, outFh, updater, true)
+	copied, err := IdleTimeoutCopy(ctx, cancel, resp.Body, outFh, updater, false)
 	if err != nil {
 		return 0, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/longhorn/longhorn-engine/pkg/sync
 github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
 github.com/longhorn/longhorn-engine/pkg/util/disk
-# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250109065136-562df2f4642b
+# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250113052932-5bd1d71da7b6
 ## explicit; go 1.23.0
 github.com/longhorn/longhorn-spdk-engine/pkg/api
 github.com/longhorn/longhorn-spdk-engine/pkg/client


### PR DESCRIPTION
ref: https://github.com/longhorn/longhorn/issues/9876

skip writing zero when dumping data to backing image lvol
update the spdk engine go mod in this repo