### PR TITLE
fix: fix backing image fail after node reboot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/longhorn/go-common-libs v0.0.0-20250204050409-8ebd4432fd70
 	github.com/longhorn/go-spdk-helper v0.0.0-20250116051812-eabe34a4219e
 	github.com/longhorn/longhorn-engine v1.8.0
-	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250131100637-6e966aacbb06
+	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250210191736-b5b59bf2263d
 	github.com/longhorn/types v0.0.0-20241225162202-00d3a5fd7502
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/longhorn/go-spdk-helper v0.0.0-20250116051812-eabe34a4219e h1:rBySu2+
 github.com/longhorn/go-spdk-helper v0.0.0-20250116051812-eabe34a4219e/go.mod h1:2NT1Xz4rBNecYAQmj/UqHz5D3UEDZZkiv2hcmVB7kqM=
 github.com/longhorn/longhorn-engine v1.8.0 h1:IP9BhaaauhGRgZcQiIYZu5KPanGk2TY2eJKtf5X635A=
 github.com/longhorn/longhorn-engine v1.8.0/go.mod h1:c89UOxNtAnTH6qGPP+KQmbPBW3RmvjtVLePQ8BS+xZE=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250131100637-6e966aacbb06 h1:1XiGSGwcg1ZsoDqsjYJKcbeaj8jR5F2lxt20wRul40Y=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250131100637-6e966aacbb06/go.mod h1:J+SLXoP08OsyxsyvVjY8WUVUb2zQNh3KmeMy6YNW318=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250210191736-b5b59bf2263d h1:IyOYYreGYuQPx162jU9akpXOmxtYYqCMZlm1vfGbXgQ=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250210191736-b5b59bf2263d/go.mod h1:J+SLXoP08OsyxsyvVjY8WUVUb2zQNh3KmeMy6YNW318=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c h1:OFz3haCSPdgiiJvXLBeId/4dPu0dxIEqkQkfNMufLwc=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c/go.mod h1:dfbJqfI8+T9ZCp5zhTYcBi/64hPBNt5/vFF3gTlfMmc=
 github.com/longhorn/types v0.0.0-20241225162202-00d3a5fd7502 h1:jgw7nosooLe1NQEdCGzM/nEOFzPcurNO+0PDsicc5+A=

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/backing_image.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/backing_image.go
@@ -131,7 +131,7 @@ func (bi *BackingImage) Create(spdkClient *spdkclient.Client, superiorPortAlloca
 		if err != nil {
 			bi.log.WithError(err).Error("Failed to create backing image")
 		}
-		// update the backing image afte preparing
+		// update the backing image after preparing
 		bi.UpdateCh <- nil
 	}()
 

--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/server.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/server.go
@@ -286,7 +286,7 @@ func (s *Server) verify() (err error) {
 				logrus.WithError(err).Warnf("failed to extract backing image name and disk UUID from lvol name %v", lvolName)
 				continue
 			}
-			actualSize := bdevLvol.DriverSpecific.Lvol.NumAllocatedClusters * uint64(defaultClusterSize)
+			size := bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)
 			alias := bdevLvol.Aliases[0]
 			expectedChecksum, err := GetSnapXattr(spdkClient, alias, types.BackingImageSnapshotAttrChecksum)
 			if err != nil {
@@ -298,7 +298,7 @@ func (s *Server) verify() (err error) {
 				logrus.WithError(err).Warnf("failed to retrieve backing image UUID attribute for snapshot %v", alias)
 				continue
 			}
-			backingImage := NewBackingImage(s.ctx, backingImageName, backingImageUUID, lvsUUID, actualSize, expectedChecksum, s.updateChs[types.InstanceTypeBackingImage])
+			backingImage := NewBackingImage(s.ctx, backingImageName, backingImageUUID, lvsUUID, size, expectedChecksum, s.updateChs[types.InstanceTypeBackingImage])
 			backingImage.Alias = alias
 			// For uncahced backing image, we set the state to pending first, so we can distinguish it from the cached but starting backing image
 			backingImage.State = types.BackingImageStatePending

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,7 +264,7 @@ github.com/longhorn/longhorn-engine/pkg/sync
 github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
 github.com/longhorn/longhorn-engine/pkg/util/disk
-# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250131100637-6e966aacbb06
+# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250210191736-b5b59bf2263d
 ## explicit; go 1.23.0
 github.com/longhorn/longhorn-spdk-engine/pkg/api
 github.com/longhorn/longhorn-spdk-engine/pkg/client


### PR DESCRIPTION
ref: [longhorn/longhorn 10342](https://github.com/longhorn/longhorn/issues/10342)

Since we skip writing zero into the lvol when creating v2 backing image
the size of the backing image should be `bdevLvol.NumBlocks * uint64(bdevLvol.BlockSize)` instead of using `NumAllocatedClusters`

For example, parrot is 32 MB but it only allocates 6 clusters
We should report 32MB when getting the backing image size.