### PR TITLE
fix: remove unnecessary commands and add gpg key verification back

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -24,14 +24,8 @@ CMD ["ci"]
 RUN zypper -n ref && \
     zypper update -y
 
-RUN for i in {1..10}; do \
-        zypper refresh && \
-        zypper -n addrepo --refresh https://download.opensuse.org/repositories/system:/snappy/SLE_15/system:snappy.repo && \
-        zypper -n --gpg-auto-import-keys ref && break || sleep 1; \
-    done
-
 # Install packages
-RUN zypper --no-gpg-checks -n install cmake wget curl git less file \
+RUN zypper -n install cmake wget curl git less file \
     libglib-2_0-0 libkmod-devel libnl3-devel linux-glibc-devel pkg-config \
     psmisc tox qemu-tools fuse python3-devel git zlib-devel zlib-devel-static \
     bash-completion rdma-core-devel libibverbs xsltproc docbook-xsl-stylesheets \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -81,7 +81,6 @@ RUN export REPO_OVERRIDE="" && \
 # Build spdk
 RUN export REPO_OVERRIDE="" && \
     export COMMIT_ID_OVERRIDE="" && \
-    cat /usr/src/dep-versions/scripts/build-spdk.sh && \
     bash /usr/src/dep-versions/scripts/build-spdk.sh "${REPO_OVERRIDE}" "${COMMIT_ID_OVERRIDE}" "${ARCH}"
 
 # Build libjson-c-devel


### PR DESCRIPTION
1. No need to snappy repo for the build container
2. No need to printout the build script
3. Need to verify gpg key when installing package

longhorn/longhorn#9456

