### PR TITLE
chore(Docker): use liburing2-devel for SPDK ublk

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -58,7 +58,7 @@ RUN for i in {1..10}; do \
     done
 
 
-RUN zypper -n install liburing-devel
+RUN zypper -n install liburing2-devel
 RUN zypper -n install cmake gcc xsltproc docbook-xsl-stylesheets git python311 python311-pip patchelf fuse3-devel jq wget
 
 RUN git clone https://github.com/longhorn/dep-versions.git -b ${SRC_BRANCH} /usr/src/dep-versions && \


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

SPDK ublk needs liburing2.

- amd64 liburing-devel is already liburing2.
- arm64 needs to install liburing2-devel explicitly.

ref: https://github.com/spdk/spdk/issues/3282

#### Special notes for your reviewer:

#### Additional documentation or context
