### PR TITLE
fix: no need to manually install liburing

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -58,7 +58,6 @@ RUN for i in {1..10}; do \
     done
 
 
-RUN zypper -n install liburing2-devel
 RUN zypper -n install cmake gcc xsltproc docbook-xsl-stylesheets git python311 python311-pip patchelf fuse3-devel jq wget
 
 RUN git clone https://github.com/longhorn/dep-versions.git -b ${SRC_BRANCH} /usr/src/dep-versions && \


### PR DESCRIPTION
We already specify the flag when building SPDK here https://github.com/longhorn/dep-versions/blob/d6a5694e59025d13a32bc2d86fe02d6ccfcb9ac6/scripts/build-spdk.sh#L42

longhorn/longhorn#10768

