### PR TITLE
feat(proxy): implement ReplicaRebuildingQosSet for SPDK replica 

### DIFF
--- a/pkg/client/proxy_types.go
+++ b/pkg/client/proxy_types.go
@@ -67,11 +67,12 @@ type EngineBackupInfo struct {
 }
 
 type ReplicaRebuildStatus struct {
-	Error              string
-	IsRebuilding       bool
-	Progress           int
-	State              string
-	FromReplicaAddress string
+	Error                 string
+	IsRebuilding          bool
+	Progress              int
+	State                 string
+	FromReplicaAddress    string
+	AppliedRebuildingMbps int64
 }
 
 type SnapshotHashStatus struct {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -31,6 +31,7 @@ type ProxyOps interface {
 	ReplicaAdd(context.Context, *rpc.EngineReplicaAddRequest) (*emptypb.Empty, error)
 	ReplicaList(context.Context, *rpc.ProxyEngineRequest) (*rpc.EngineReplicaListProxyResponse, error)
 	ReplicaRebuildingStatus(context.Context, *rpc.ProxyEngineRequest) (*rpc.EngineReplicaRebuildStatusProxyResponse, error)
+	ReplicaRebuildingQosSet(context.Context, *rpc.EngineReplicaRebuildingQosSetRequest) (*emptypb.Empty, error)
 	ReplicaRemove(context.Context, *rpc.EngineReplicaRemoveRequest) (*emptypb.Empty, error)
 	ReplicaVerifyRebuild(context.Context, *rpc.EngineReplicaVerifyRebuildRequest) (*emptypb.Empty, error)
 	ReplicaModeUpdate(context.Context, *rpc.EngineReplicaModeUpdateRequest) (*emptypb.Empty, error)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/longhorn/longhorn/issues/10770

#### What this PR does / why we need it:

- Adds a new `ReplicaRebuildingQosSet()` gRPC method to the `ProxyEngineService`
- Implements logic in `V2DataEngineProxyOps` to apply QoS settings to all WO replicas

#### Special notes for your reviewer:

- Only WO (Write-Only) mode replicas are targeted for QoS

#### Additional documentation or context
