### PR TITLE
chore(deps): update go-spdk-helper and longhorn-spdk-engine version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/longhorn/go-common-libs v0.0.0-20250510103049-801acb30430c
 	github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369
 	github.com/longhorn/longhorn-engine v1.9.0-rc2
-	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709
+	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250513081413-5b351018f7f4
 	github.com/longhorn/types v0.0.0-20250416235128-0c407ad2b792
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/longhorn/backupstore v0.0.0-20250421031654-0ef762b84472
 	github.com/longhorn/go-common-libs v0.0.0-20250510103049-801acb30430c
-	github.com/longhorn/go-spdk-helper v0.0.0-20250511111201-ed9e6caeaf23
+	github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369
 	github.com/longhorn/longhorn-engine v1.9.0-rc2
 	github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709
 	github.com/longhorn/types v0.0.0-20250416235128-0c407ad2b792
@@ -34,7 +34,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.16.0 // indirect
 	github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,9 @@ github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8 h1:SjZ2GvvOononHOpK
 github.com/c9s/goprocinfo v0.0.0-20210130143923-c95fcf8c64a8/go.mod h1:uEyr4WpAH4hio6LFriaPkL938XnrvLpNPmQHBdrmbIE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
 github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -114,8 +115,8 @@ github.com/longhorn/go-common-libs v0.0.0-20250510103049-801acb30430c h1:/ZCU7cI
 github.com/longhorn/go-common-libs v0.0.0-20250510103049-801acb30430c/go.mod h1:jmpkf0LHUnYAzc57uzfCzMnnYgtaWn1qounGJOlpjNo=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250425050615-1de428a1281a h1:rvUgmO0v6LTpIqoGn0n3nLFmchHyvoVZ8EePnt4bEqA=
 github.com/longhorn/go-iscsi-helper v0.0.0-20250425050615-1de428a1281a/go.mod h1:6otI70HGdPUKJTRHCU9qlcpFJO6b5LXSrVWy3pciNww=
-github.com/longhorn/go-spdk-helper v0.0.0-20250511111201-ed9e6caeaf23 h1:BGE0weIAPn1yZM5SeZfoo/iYf+I6b7TtQBCd5lgO/Ec=
-github.com/longhorn/go-spdk-helper v0.0.0-20250511111201-ed9e6caeaf23/go.mod h1:lZYWKf8YNOV4TSf57u8Tj1ilDQLQlW2M/HgFlecoRno=
+github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369 h1:b1KncvIt4E3/Hlx20cGayGjwqvYNScRDZYLLQUHzG2A=
+github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369/go.mod h1:lZYWKf8YNOV4TSf57u8Tj1ilDQLQlW2M/HgFlecoRno=
 github.com/longhorn/longhorn-engine v1.9.0-rc2 h1:iFnPflJi/OZkTv4zyzOQ4dACQUoHxUJ79WxL6NkC0Zk=
 github.com/longhorn/longhorn-engine v1.9.0-rc2/go.mod h1:bWsmS/h2bDZL9OdVJ4OdqulH48wNxWZpTHbx9I1CP4A=
 github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709 h1:QN54M+xr2iDGzCbx85KWSI6wt7Y2qqIfVEIMG3uY5BA=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369 h1:b1KncvI
 github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369/go.mod h1:lZYWKf8YNOV4TSf57u8Tj1ilDQLQlW2M/HgFlecoRno=
 github.com/longhorn/longhorn-engine v1.9.0-rc2 h1:iFnPflJi/OZkTv4zyzOQ4dACQUoHxUJ79WxL6NkC0Zk=
 github.com/longhorn/longhorn-engine v1.9.0-rc2/go.mod h1:bWsmS/h2bDZL9OdVJ4OdqulH48wNxWZpTHbx9I1CP4A=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709 h1:QN54M+xr2iDGzCbx85KWSI6wt7Y2qqIfVEIMG3uY5BA=
-github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709/go.mod h1:q4XGgXrGwMs/UPeJLXgfc99dcAfY32nRDf9TaaED3Jo=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250513081413-5b351018f7f4 h1:JFPyFhUinUlGholNj7u1yNQYJqGmKaiLLYHE23JTkTk=
+github.com/longhorn/longhorn-spdk-engine v0.0.0-20250513081413-5b351018f7f4/go.mod h1:/FKQ17VOVd5jGHpAOIN5B7RnH6Q4CjreK+VOsmymHNg=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c h1:OFz3haCSPdgiiJvXLBeId/4dPu0dxIEqkQkfNMufLwc=
 github.com/longhorn/sparse-tools v0.0.0-20241216160947-2b328f0fa59c/go.mod h1:dfbJqfI8+T9ZCp5zhTYcBi/64hPBNt5/vFF3gTlfMmc=
 github.com/longhorn/types v0.0.0-20250416235128-0c407ad2b792 h1:+KWYQQKGCBnoy7Our2ryJ9HtUksKf3OPaLVMfsxPzMk=

--- a/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
+++ b/vendor/github.com/cpuguy83/go-md2man/v2/md2man/md2man.go
@@ -1,3 +1,4 @@
+// Package md2man aims in converting markdown into roff (man pages).
 package md2man
 
 import (

--- a/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/lvol.go
+++ b/vendor/github.com/longhorn/go-spdk-helper/pkg/spdk/types/lvol.go
@@ -47,10 +47,11 @@ type ShallowCopy struct {
 }
 
 type ShallowCopyStatus struct {
-	State          string `json:"state"`
-	CopiedClusters uint64 `json:"copied_clusters"`
-	TotalClusters  uint64 `json:"total_clusters"`
-	Error          string `json:"error,omitempty"`
+	State            string `json:"state"`
+	CopiedClusters   uint64 `json:"copied_clusters"`
+	UnmappedClusters uint64 `json:"unmapped_clusters,omitempty"`
+	TotalClusters    uint64 `json:"total_clusters"`
+	Error            string `json:"error,omitempty"`
 }
 
 type BdevLvolCreateLvstoreRequest struct {
@@ -149,6 +150,12 @@ type BdevLvolShallowCopyRequest struct {
 	DstBdevName string `json:"dst_bdev_name"`
 }
 
+type BdevLvolRangeShallowCopyRequest struct {
+	SrcLvolName string   `json:"src_lvol_name"`
+	DstBdevName string   `json:"dst_bdev_name"`
+	Clusters    []uint64 `json:"clusters"`
+}
+
 type BdevLvolGetFragmapRequest struct {
 	Name   string `json:"name"`
 	Offset uint64 `json:"offset"`
@@ -164,12 +171,27 @@ type BdevLvolRegisterSnapshotChecksumRequest struct {
 	Name string `json:"name"`
 }
 
+type BdevLvolRegisterRangeChecksumsRequest struct {
+	Name string `json:"name"`
+}
+
 type BdevLvolGetSnapshotChecksumRequest struct {
 	Name string `json:"name"`
 }
 
+type BdevLvolGetRangeChecksumsRequest struct {
+	Name              string `json:"name"`
+	ClusterStartIndex uint64 `json:"cluster_start_index"`
+	ClusterCount      uint64 `json:"cluster_count"`
+}
+
 type BdevLvolSnapshotChecksum struct {
 	Checksum uint64 `json:"checksum"`
+}
+
+type BdevLvolRangeChecksum struct {
+	ClusterIndex uint64 `json:"cluster_index"`
+	Checksum     uint64 `json:"checksum"`
 }
 
 type BdevLvolStopSnapshotChecksumRequest struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -256,7 +256,7 @@ github.com/longhorn/longhorn-engine/pkg/sync
 github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
 github.com/longhorn/longhorn-engine/pkg/util/disk
-# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250507054315-c1b689d69709
+# github.com/longhorn/longhorn-spdk-engine v0.0.0-20250513081413-5b351018f7f4
 ## explicit; go 1.24.0
 github.com/longhorn/longhorn-spdk-engine/pkg/api
 github.com/longhorn/longhorn-spdk-engine/pkg/client

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -112,8 +112,8 @@ github.com/c9s/goprocinfo/linux
 # github.com/cespare/xxhash/v2 v2.3.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cpuguy83/go-md2man/v2 v2.0.5
-## explicit; go 1.11
+# github.com/cpuguy83/go-md2man/v2 v2.0.7
+## explicit; go 1.12
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
@@ -234,7 +234,7 @@ github.com/longhorn/go-iscsi-helper/iscsidev
 github.com/longhorn/go-iscsi-helper/longhorndev
 github.com/longhorn/go-iscsi-helper/types
 github.com/longhorn/go-iscsi-helper/util
-# github.com/longhorn/go-spdk-helper v0.0.0-20250511111201-ed9e6caeaf23
+# github.com/longhorn/go-spdk-helper v0.0.0-20250513010708-f55efaeb7369
 ## explicit; go 1.23.0
 github.com/longhorn/go-spdk-helper/pkg/initiator
 github.com/longhorn/go-spdk-helper/pkg/jsonrpc


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
Issue https://github.com/longhorn/longhorn/issues/10799

#### What this PR does / why we need it:
Updated the version of go-spdk-helper and longhorn-spdk-engine with the new APIs for delta snapshot rebuilding

#### Special notes for your reviewer:

#### Additional documentation or context
