### PR TITLE
fix: allow removal of v2 volume head's parent

### DIFF
--- a/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/engine.go
+++ b/vendor/github.com/longhorn/longhorn-spdk-engine/pkg/spdk/engine.go
@@ -1886,12 +1886,6 @@ func (e *Engine) snapshotOperationPreCheckWithoutLock(replicaClients map[string]
 			if len(e.SnapshotMap[snapshotName].Children) > 1 {
 				return "", fmt.Errorf("engine %s cannot delete snapshot %s since it contains multiple children %+v", e.Name, snapshotName, e.SnapshotMap[snapshotName].Children)
 			}
-			// TODO: SPDK allows deleting the parent of the volume head. To make the behavior consistent between v1 and v2 engines, we manually disable if for now.
-			for childName := range e.SnapshotMap[snapshotName].Children {
-				if childName == types.VolumeHead {
-					return "", fmt.Errorf("engine %s cannot delete snapshot %s since it is the parent of volume head", e.Name, snapshotName)
-				}
-			}
 		case SnapshotOperationRevert:
 			if snapshotName == "" {
 				return "", fmt.Errorf("empty snapshot name for engine %s snapshot deletion", e.Name)


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #9064

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
