### PR TITLE
feat: improve logging precision to nanoseconds

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -35,7 +36,8 @@ func main() {
 			funcName := path.Base(f.Function)
 			return funcName, fileName
 		},
-		FullTimestamp: true,
+		TimestampFormat: time.RFC3339Nano,
+		FullTimestamp:   true,
 	})
 
 	a.Before = func(c *cli.Context) error {

--- a/pkg/util/log.go
+++ b/pkg/util/log.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -69,6 +70,8 @@ func SetUpLogger(logsDir string) error {
 				funcName := path.Base(f.Function)
 				return funcName, fileName
 			},
+			TimestampFormat: time.RFC3339Nano,
+			FullTimestamp:   true,
 		},
 		LogsDir: logsDir,
 	})


### PR DESCRIPTION

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#11596

#### What this PR does / why we need it:

Currently, the log output from Longhorn components uses the default logrus timestamp format, which typically provides only second- or millisecond-level precision.
For debugging and performance analysis, especially when investigating I/O latency and replica rebuilding, it would be helpful to increase timestamp precision to nanoseconds.


#### Special notes for your reviewer:

#### Additional documentation or context
