### PR TITLE
fix(proxy): restrict backup env injection to a credential allowlist (GHSA-wgh7-5vxp-4qr4)

### DIFF
--- a/pkg/proxy/backup.go
+++ b/pkg/proxy/backup.go
@@ -440,14 +440,25 @@ func (ops V2DataEngineProxyOps) BackupRestoreStatus(ctx context.Context, req *rp
 	return resp, nil
 }
 
+// setEnv exports caller-supplied KEY=VALUE entries into the process
+// environment so that github.com/longhorn/backupstore helpers (which consume
+// credentials through os.Getenv) can observe them.
+//
+// Keys are first validated against backupEnvAllowlist. Any unknown key —
+// including LD_PRELOAD, LD_LIBRARY_PATH, LD_AUDIT, PATH, and similar loader
+// variables — causes the whole request to be rejected before any os.Setenv
+// call is made, so partially-applied state cannot leak. See
+// GHSA-wgh7-5vxp-4qr4.
 func setEnv(envs []string) error {
+	if err := validateBackupEnv(envs); err != nil {
+		return err
+	}
 	for _, env := range envs {
-		part := strings.SplitN(env, "=", 2)
-		if len(part) < 2 {
-			continue
+		key, value, ok := strings.Cut(env, "=")
+		if !ok {
+			return fmt.Errorf("invalid environment entry %q: expected KEY=VALUE", env)
 		}
-
-		if err := os.Setenv(part[0], part[1]); err != nil {
+		if err := os.Setenv(key, value); err != nil {
 			return err
 		}
 	}

--- a/pkg/proxy/backup_test.go
+++ b/pkg/proxy/backup_test.go
@@ -1,0 +1,181 @@
+package proxy
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestSetEnv_RejectsUnsafeLoaderKeys is the direct regression test for
+// GHSA-wgh7-5vxp-4qr4.
+func TestSetEnv_RejectsUnsafeLoaderKeys(t *testing.T) {
+	unsafeKeys := []string{
+		"LD_PRELOAD",
+		"LD_LIBRARY_PATH",
+		"LD_AUDIT",
+		"PATH",
+		"GOTRACEBACK",
+		"PYTHONPATH",
+		"NSS_WRAPPER_PASSWD",
+	}
+
+	for _, key := range unsafeKeys {
+		t.Run(key, func(t *testing.T) {
+			origVal, origSet := os.LookupEnv(key)
+			if err := os.Unsetenv(key); err != nil {
+				t.Fatalf("precondition: unable to clear %s: %v", key, err)
+			}
+			t.Cleanup(func() {
+				if origSet {
+					_ = os.Setenv(key, origVal)
+				} else {
+					_ = os.Unsetenv(key)
+				}
+			})
+
+			err := setEnv([]string{key + "=/tmp/evil.so"})
+			if err == nil {
+				t.Fatalf("setEnv(%s=...) returned nil error; expected allowlist rejection", key)
+			}
+			if !strings.Contains(err.Error(), "not permitted") {
+				t.Fatalf("setEnv(%s=...) returned %q; expected 'not permitted by the backup env allowlist'", key, err)
+			}
+			if got, ok := os.LookupEnv(key); ok {
+				t.Fatalf("setEnv rejected %s but it is now set to %q; process state must not change on rejection", key, got)
+			}
+		})
+	}
+}
+
+func TestSetEnv_RejectsMalformedEntries(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+	}{
+		{"no separator", "LDPRELOAD"},
+		{"empty key", "=value"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := setEnv([]string{tc.env}); err == nil {
+				t.Fatalf("setEnv(%q) returned nil error; expected rejection", tc.env)
+			}
+		})
+	}
+}
+
+func TestSetEnv_AcceptsAllowlistedCredentials(t *testing.T) {
+	allowlisted := []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_ENDPOINTS",
+		"AWS_CERT",
+		"VIRTUAL_HOSTED_STYLE",
+		"CIFS_USERNAME",
+		"CIFS_PASSWORD",
+		"AZBLOB_ACCOUNT_NAME",
+		"AZBLOB_ACCOUNT_KEY",
+		"AZBLOB_ENDPOINT",
+		"AZBLOB_CERT",
+		"HTTPS_PROXY",
+		"HTTP_PROXY",
+		"NO_PROXY",
+	}
+
+	saved := make(map[string]*string, len(allowlisted))
+	for _, k := range allowlisted {
+		if v, ok := os.LookupEnv(k); ok {
+			s := v
+			saved[k] = &s
+		} else {
+			saved[k] = nil
+		}
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			if v == nil {
+				_ = os.Unsetenv(k)
+			} else {
+				_ = os.Setenv(k, *v)
+			}
+		}
+	})
+
+	envs := make([]string, 0, len(allowlisted))
+	for _, k := range allowlisted {
+		envs = append(envs, k+"=proxy-allowlist-test")
+	}
+	if err := setEnv(envs); err != nil {
+		t.Fatalf("setEnv(allowlisted credentials) returned %v; expected nil", err)
+	}
+	for _, k := range allowlisted {
+		if got := os.Getenv(k); got != "proxy-allowlist-test" {
+			t.Fatalf("setEnv did not export %s correctly; got %q", k, got)
+		}
+	}
+}
+
+func TestSetEnv_AtomicOnReject(t *testing.T) {
+	const safeKey = "AWS_ACCESS_KEY_ID"
+	const unsafeKey = "LD_PRELOAD"
+	const marker = "proxy-atomicity-marker"
+
+	origSafe, safeSet := os.LookupEnv(safeKey)
+	origUnsafe, unsafeSet := os.LookupEnv(unsafeKey)
+	_ = os.Unsetenv(safeKey)
+	_ = os.Unsetenv(unsafeKey)
+	t.Cleanup(func() {
+		if safeSet {
+			_ = os.Setenv(safeKey, origSafe)
+		} else {
+			_ = os.Unsetenv(safeKey)
+		}
+		if unsafeSet {
+			_ = os.Setenv(unsafeKey, origUnsafe)
+		} else {
+			_ = os.Unsetenv(unsafeKey)
+		}
+	})
+
+	err := setEnv([]string{
+		safeKey + "=" + marker,
+		unsafeKey + "=/tmp/evil.so",
+	})
+	if err == nil {
+		t.Fatalf("setEnv with unsafe entry returned nil; expected rejection")
+	}
+	if got, ok := os.LookupEnv(safeKey); ok {
+		t.Fatalf("setEnv returned an error but still exported %s=%q; must be atomic", safeKey, got)
+	}
+	if _, ok := os.LookupEnv(unsafeKey); ok {
+		t.Fatalf("setEnv leaked the unsafe key %s into the environment", unsafeKey)
+	}
+}
+
+func TestValidateBackupEnv_TableDriven(t *testing.T) {
+	cases := []struct {
+		name    string
+		envs    []string
+		wantErr bool
+	}{
+		{"empty slice", nil, false},
+		{"single allowlisted", []string{"AWS_ACCESS_KEY_ID=x"}, false},
+		{"allow empty value", []string{"HTTP_PROXY="}, false},
+		{"LD_PRELOAD rejected", []string{"LD_PRELOAD=/tmp/x.so"}, true},
+		{"mixed good and bad rejected", []string{"AWS_ACCESS_KEY_ID=x", "PATH=/bin"}, true},
+		{"malformed no equals rejected", []string{"NOEQUALS"}, true},
+		{"empty key rejected", []string{"=value"}, true},
+		{"case-sensitive: aws_access_key_id rejected", []string{"aws_access_key_id=x"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBackupEnv(tc.envs)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateBackupEnv(%v) returned nil; expected error", tc.envs)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateBackupEnv(%v) returned %v; expected nil", tc.envs, err)
+			}
+		})
+	}
+}

--- a/pkg/proxy/env_allowlist.go
+++ b/pkg/proxy/env_allowlist.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+
+	btypes "github.com/longhorn/backupstore/types"
+)
+
+// backupEnvAllowlist enumerates every environment variable key that the proxy
+// is permitted to forward from untrusted gRPC callers into the instance-manager
+// process. Every entry corresponds to a credential or proxy setting consumed
+// by github.com/longhorn/backupstore when talking to the configured backup
+// target (S3, CIFS, Azure Blob).
+//
+// Anything outside this set — in particular the loader variables LD_PRELOAD,
+// LD_LIBRARY_PATH, LD_AUDIT, as well as PATH, GOTRACEBACK, PYTHONPATH, NSS_* —
+// is rejected. A caller that reaches the proxy gRPC port must not be able to
+// influence how subsequent exec.Command invocations resolve binaries or load
+// shared libraries into the (root, privileged) instance-manager container.
+//
+// See GHSA-wgh7-5vxp-4qr4.
+var backupEnvAllowlist = map[string]struct{}{
+	// S3 / AWS
+	btypes.AWSAccessKey:       {},
+	btypes.AWSSecretKey:       {},
+	btypes.AWSEndPoint:        {},
+	btypes.AWSCert:            {},
+	btypes.VirtualHostedStyle: {},
+
+	// CIFS
+	btypes.CIFSUsername: {},
+	btypes.CIFSPassword: {},
+
+	// Azure Blob
+	btypes.AZBlobAccountName: {},
+	btypes.AZBlobAccountKey:  {},
+	btypes.AZBlobEndpoint:    {},
+	btypes.AZBlobCert:        {},
+
+	// Outbound proxy (required so backupstore HTTP clients reach the target)
+	btypes.HTTPSProxy: {},
+	btypes.HTTPProxy:  {},
+	btypes.NOProxy:    {},
+}
+
+// isBackupEnvAllowed reports whether key is safe to propagate into the
+// instance-manager process environment.
+func isBackupEnvAllowed(key string) bool {
+	_, ok := backupEnvAllowlist[key]
+	return ok
+}
+
+// validateBackupEnv returns a non-nil error if any entry in envs is malformed
+// or carries a key that is not a member of backupEnvAllowlist. It never
+// mutates process state; callers must invoke it as a gate before calling
+// os.Setenv, so that a single unsafe key rejects the whole request and no
+// partial state leaks into the running process.
+func validateBackupEnv(envs []string) error {
+	for _, env := range envs {
+		key, _, ok := strings.Cut(env, "=")
+		if !ok {
+			return fmt.Errorf("malformed env entry %q: expected KEY=VALUE", env)
+		}
+		if key == "" {
+			return fmt.Errorf("malformed env entry %q: empty key", env)
+		}
+		if !isBackupEnvAllowed(key) {
+			return fmt.Errorf("env key %q is not permitted by the backup env allowlist", key)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

`setEnv()` in `pkg/proxy/backup.go` forwarded every caller-supplied
`KEY=VALUE` entry from the proxy gRPC request straight into `os.Setenv()`
without any key validation. A caller with pod-network reachability to the
instance-manager proxy port (8501) could therefore set loader variables
such as `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, or `PATH`. Since
`setEnv()` mutates the shared process environment, every subsequent
`exec.Command` spawned by the instance-manager container (privileged,
typically root) inherited those values and could be coerced into loading
an attacker-controlled shared object.

This PR restricts `setEnv()` to the fourteen environment variable keys
that `github.com/longhorn/backupstore` actually reads via `os.Getenv`.
Anything outside that allowlist is rejected before any `os.Setenv` call
is made.

Security advisory: **GHSA-wgh7-5vxp-4qr4**

## Impact (pre-patch)

- Unauthenticated environment-variable injection via
  `ProxyEngineService/SnapshotBackup` and `ProxyEngineService/BackupRestore`.
- Arbitrary code execution in the instance-manager container context
  through loader hijacking.
- Pod-network reachability to TCP/8501 is sufficient.

PoC:

```
grpcurl -plaintext <node-ip>:8501 ProxyEngineService/SnapshotBackup \
  '{"address":"127.0.0.1:8500","backup_name":"x","snapshot_name":"x",
    "envs":["LD_PRELOAD=/tmp/evil.so"]}'
```

## Fix

1. New file `pkg/proxy/env_allowlist.go` defines `backupEnvAllowlist` —
   the keys consumed by `github.com/longhorn/backupstore`:
   - S3/AWS: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINTS`, `AWS_CERT`, `VIRTUAL_HOSTED_STYLE`
   - CIFS: `CIFS_USERNAME`, `CIFS_PASSWORD`
   - Azure: `AZBLOB_ACCOUNT_NAME`, `AZBLOB_ACCOUNT_KEY`, `AZBLOB_ENDPOINT`, `AZBLOB_CERT`
   - Proxy: `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`

   The string constants are imported from
   `github.com/longhorn/backupstore/types`, so the allowlist stays in sync
   with the consumer automatically.

2. `validateBackupEnv` runs **before** any `os.Setenv` call and rejects
   the whole request on the first violation. A batch that mixes a safe
   key with an unsafe one is rejected atomically; no partial mutation of
   process state is possible.

3. `setEnv()` now calls `validateBackupEnv` as its first step and uses
   `strings.Cut` for parsing.

No behavioural change for legitimate callers: Longhorn only ever sends
credential and proxy keys, all of which are on the allowlist.

### Why not remove `os.Setenv` entirely?

`github.com/longhorn/backupstore/util/credential.go` reads credentials
through `os.Getenv`, so eliminating global env mutation from this file
would require a coordinated change in the `longhorn/backupstore` repo.
An allowlist fully closes the advisory without that dependency; a
follow-up refactor can happen separately.

## Testing

New test file `pkg/proxy/backup_test.go` covers:

- `TestSetEnv_RejectsUnsafeLoaderKeys` — direct regression test:
  `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, `PATH`, `GOTRACEBACK`,
  `PYTHONPATH`, `NSS_WRAPPER_PASSWD` are all rejected and never appear
  in `os.Environ()` afterwards.
- `TestSetEnv_RejectsMalformedEntries` — inputs without `=` and with an
  empty key are rejected.
- `TestSetEnv_AcceptsAllowlistedCredentials` — positive case: every
  allowlisted key is still exportable (hermetic, restores env on cleanup).
- `TestSetEnv_AtomicOnReject` — a batch mixing a safe key with
  `LD_PRELOAD` leaves the safe key unset after the rejected call.
- `TestValidateBackupEnv_TableDriven` — validator coverage incl.
  case-sensitivity (`aws_access_key_id` rejected).

Run:

```
go test ./pkg/proxy/...
```

## Backport

Clean cherry-pick candidates: `v1.5.x`, `v1.6.x`, `v1.7.x`, `v1.8.x`,
`v1.9.x`, `v1.10.x`, `v1.11.x` (all share the same `setEnv` helper).

## Credit

Reported by @mert2m as GHSA-wgh7-5vxp-4qr4.

## Checklist

- [x] Allowlist covers every env key consumed by `github.com/longhorn/backupstore`
- [x] No behavioural change for legitimate callers
- [x] `LD_PRELOAD` / `LD_LIBRARY_PATH` / `LD_AUDIT` / `PATH` regression tests
- [x] Atomicity test (partial application impossible)
- [x] No new dependencies (reuses already-vendored `backupstore/types`)