### PR TITLE
fix: prestop should not delete device mapper devices

### DIFF
--- a/package/instance-manager-v2-prestop
+++ b/package/instance-manager-v2-prestop
@@ -7,16 +7,6 @@ log() {
 function cleanup_spdk_resources() {
     log "Caught termination signal. Cleaning up SPDK resources..."
 
-    local v2_devices=($(get_v2_devices))
-    for device in "${v2_devices[@]}"; do
-        dmsetup remove "$device"
-        log "Removed device-mapper device: $device"
-
-        device_file="/host/dev/longhorn/$device"
-        rm "$device_file"
-        log "Removed device file: $device_file"
-    done
-
     log "Sending SIGTERM to go-spdk-helper to stop spdk_tgt..."
     go-spdk-helper kill-instance --sig-name SIGTERM
     if [[ $? -ne 0 ]]; then
@@ -44,31 +34,6 @@ function cleanup_spdk_resources() {
     else
         log "Failed to send SIGKILL to spdk_tgt (process may have already exited)"
     fi
-}
-
-function get_v2_devices() {
-    local dm_devices
-    dm_devices=$(dmsetup ls 2>/dev/null | awk '{print $1}')
-    local v2_devices=()
-
-    if [[ ! -d /host/dev/longhorn/ ]]; then
-        echo "${v2_devices[@]}"
-        return
-    fi
-
-    local device_files
-    device_files=$(ls /host/dev/longhorn/)
-
-    for dm_device in $dm_devices; do
-        for device_file in $device_files; do
-            if [[ "$dm_device" == "$device_file" ]]; then
-                v2_devices+=("$dm_device")
-                break
-            fi
-        done
-    done
-
-    echo "${v2_devices[@]}"
 }
 
 cleanup_spdk_resources


### PR DESCRIPTION



#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue Longhorn/longhorn#13194

#### What this PR does / why we need it:

prestop should not delete device mapper devices. The cleanup lead to the teardown of the endpoints of existing v1 volumes.


#### Special notes for your reviewer:

#### Additional documentation or context
