### PR TITLE
fix(util): return error when gRPC endpoint has empty address after protocol prefix

### DIFF
--- a/pkg/util/grpcutil.go
+++ b/pkg/util/grpcutil.go
@@ -234,9 +234,12 @@ func parseEndpoint(ep string) (proto string, address string, err error) {
 		return "", "", fmt.Errorf("invalid endpoint: %v", ep)
 	}
 
-	if len(s) > 1 && s[1] != "" {
+	if len(s) > 1 {
 		if s[0] != "unix" && s[0] != "tcp" {
 			return "", "", fmt.Errorf("invalid endpoint: %v unsupported proto: %v", ep, s[0])
+		}
+		if s[1] == "" {
+			return "", "", fmt.Errorf("invalid endpoint: %v missing address", ep)
 		}
 		return s[0], s[1], nil
 	}

--- a/pkg/util/grpcutil_test.go
+++ b/pkg/util/grpcutil_test.go
@@ -18,6 +18,8 @@ func Test_parseEndpoint(t *testing.T) {
 		{name: "testEndpointUnix", args: args{ep: "unix:///tmp/test.sock"}, wantProto: "unix", wantAddress: "/tmp/test.sock", wantErr: false},
 		{name: "testEndpointTcp", args: args{ep: "tcp://127.0.0.1:8500"}, wantProto: "tcp", wantAddress: "127.0.0.1:8500", wantErr: false},
 		{name: "testEndpointProtoMissingFallback", args: args{ep: "localhost:8500"}, wantProto: "tcp", wantAddress: "localhost:8500", wantErr: false},
+		{name: "testEndpointUnixMissingAddress", args: args{ep: "unix://"}, wantProto: "", wantAddress: "", wantErr: true},
+		{name: "testEndpointTcpMissingAddress", args: args{ep: "tcp://"}, wantProto: "", wantAddress: "", wantErr: true},
 		{name: "testEndpointProtoUnsupported", args: args{ep: "unsupported://127.0.0.1:8500"}, wantProto: "", wantAddress: "", wantErr: true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue #

#### What this PR does / why we need it:

`parseEndpoint` silently returns an empty address (no error) when the input is like `unix://` or `tcp://` - protocol prefix present, address missing. Downstream gRPC dial then fails with a confusing network error instead of a clear validation message.

The fix adds an explicit check: if the address part after `://` is empty, return an error right there.

To reproduce:

```go
proto, addr, err := parseEndpoint("unix://")
// before: proto="unix", addr="", err=nil  (oops)
// after:  err != nil, "missing address"
```

#### Special notes for your reviewer:

Added two test cases covering `unix://` and `tcp://` with empty address - both now return an error as expected.

#### Additional documentation or context

n/a