### PR TITLE
fix(security): reject start when --tls-dir is set but certs are invalid

### DIFF
--- a/app/cmd/process.go
+++ b/app/cmd/process.go
@@ -248,7 +248,7 @@ func getProcessManagerClient(c *cli.Context, ctx context.Context, ctxCancel cont
 		if err == nil {
 			return imClient, err
 		}
-		logrus.WithError(err).Info("Falling back to non tls ProcessManager client")
+		return nil, errors.Wrap(err, "failed to initialize TLS ProcessManager client")
 	}
 
 	return client.NewProcessManagerClient(ctx, ctxCancel, url, nil)

--- a/app/cmd/process.go
+++ b/app/cmd/process.go
@@ -259,7 +259,7 @@ func getProcessManagerClient(c *cli.Command, ctx context.Context, ctxCancel cont
 		if err == nil {
 			return imClient, err
 		}
-		logrus.WithError(err).Info("Falling back to non tls ProcessManager client")
+		return nil, errors.Wrap(err, "failed to initialize TLS ProcessManager client")
 	}
 
 	return client.NewProcessManagerClient(ctx, ctxCancel, url, nil)

--- a/app/cmd/process_test.go
+++ b/app/cmd/process_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func newProcessClientTestContext(t *testing.T, tlsDir string) *cli.Context {
+	t.Helper()
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("url", "tcp://127.0.0.1:1", "")
+	set.String("tls-dir", tlsDir, "")
+	if err := set.Set("url", "tcp://127.0.0.1:1"); err != nil {
+		t.Fatalf("set url: %v", err)
+	}
+	if err := set.Set("tls-dir", tlsDir); err != nil {
+		t.Fatalf("set tls-dir: %v", err)
+	}
+	return cli.NewContext(cli.NewApp(), set, nil)
+}
+
+func TestGetProcessManagerClientFailsClosedWhenTLSDirInvalid(t *testing.T) {
+	c := newProcessClientTestContext(t, filepath.Join(t.TempDir(), "missing"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, err := getProcessManagerClient(c, ctx, cancel)
+
+	if err == nil {
+		t.Fatal("expected TLS initialization failure")
+	}
+	if cli != nil {
+		t.Fatal("client must be nil when TLS initialization fails")
+	}
+	if !strings.Contains(err.Error(), "failed to initialize TLS ProcessManager client") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/app/cmd/process_test.go
+++ b/app/cmd/process_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v3"
+)
+
+func newProcessClientTestCommand(t *testing.T, tlsDir string) *cli.Command {
+	t.Helper()
+	cmd := &cli.Command{
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "url", Value: "tcp://127.0.0.1:1"},
+			&cli.StringFlag{Name: "tls-dir", Value: tlsDir},
+		},
+	}
+	if err := cmd.Run(t.Context(), []string{"test"}); err != nil {
+		t.Fatalf("initialize command: %v", err)
+	}
+	return cmd
+}
+
+func TestGetProcessManagerClientFailsClosedWhenTLSDirInvalid(t *testing.T) {
+	c := newProcessClientTestCommand(t, filepath.Join(t.TempDir(), "missing"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cli, err := getProcessManagerClient(c, ctx, cancel)
+
+	if err == nil {
+		t.Fatal("expected TLS initialization failure")
+	}
+	if cli != nil {
+		t.Fatal("client must be nil when TLS initialization fails")
+	}
+	if !strings.Contains(err.Error(), "failed to initialize TLS ProcessManager client") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/app/cmd/start.go
+++ b/app/cmd/start.go
@@ -165,21 +165,17 @@ func start(c *cli.Context) (err error) {
 		}
 	}
 
-	// setup tls config
-	var tlsConfig *tls.Config
+	var serverTLSConfig *tls.Config
+	var clientTLSConfig *tls.Config
 	tlsDir := c.GlobalString("tls-dir")
 	if tlsDir != "" {
-		tlsConfig, err = util.LoadServerTLS(
-			filepath.Join(tlsDir, "ca.crt"),
-			filepath.Join(tlsDir, "tls.crt"),
-			filepath.Join(tlsDir, "tls.key"),
-			"longhorn-backend.longhorn-system")
+		serverTLSConfig, clientTLSConfig, err = loadTLSConfigsFromDir(tlsDir)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to add TLS key pair from %v", tlsDir)
+			return err
 		}
 	}
 
-	if tlsConfig != nil {
+	if serverTLSConfig != nil {
 		logrus.Info("Creating gRPC server with mtls auth")
 	} else {
 		logrus.Info("Creating gRPC server with no auth")
@@ -207,8 +203,10 @@ func start(c *cli.Context) (err error) {
 	servers := map[string]*grpc.Server{}
 	listeners := map[string]net.Listener{}
 
+	spdkClientAddr := toClientAddress(addresses[types.SpdkGrpcService])
+
 	// Start disk server
-	diskGRPCServer, diskGRPCListener, err := setupDiskGRPCServer(ctx, addresses[types.DiskGrpcService], addresses[types.SpdkGrpcService], spdkEnabled)
+	diskGRPCServer, diskGRPCListener, err := setupDiskGRPCServer(ctx, addresses[types.DiskGrpcService], spdkClientAddr, spdkEnabled, serverTLSConfig, clientTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to setup %s", types.DiskGrpcService)
 		return err
@@ -218,8 +216,8 @@ func start(c *cli.Context) (err error) {
 
 	// Start instance server
 	instanceGRPCServer, instanceRPCListener, err := setupInstanceGRPCServer(ctx, logsDir,
-		addresses[types.InstanceGrpcService], addresses[types.ProcessManagerGrpcService],
-		addresses[types.SpdkGrpcService], tlsConfig, spdkEnabled)
+		addresses[types.InstanceGrpcService], toClientAddress(addresses[types.ProcessManagerGrpcService]),
+		spdkClientAddr, serverTLSConfig, clientTLSConfig, spdkEnabled)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.InstanceGrpcService)
 		return err
@@ -229,7 +227,7 @@ func start(c *cli.Context) (err error) {
 
 	// Start proxy server
 	proxyGRPCServer, proxyGRPCListener, err := setupProxyGRPCServer(ctx, logsDir,
-		addresses[types.ProxyGRPCService], addresses[types.DiskGrpcService], addresses[types.SpdkGrpcService], tlsConfig)
+		addresses[types.ProxyGRPCService], spdkClientAddr, serverTLSConfig, clientTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.ProxyGRPCService)
 		return err
@@ -238,7 +236,7 @@ func start(c *cli.Context) (err error) {
 	listeners[types.ProxyGRPCService] = proxyGRPCListener
 
 	// Start process-manager server
-	pm, pmGRPCServer, pmGRPCListener, err := setupProcessManagerGRPCServer(ctx, processPortRange, logsDir, addresses[types.ProcessManagerGrpcService])
+	pm, pmGRPCServer, pmGRPCListener, err := setupProcessManagerGRPCServer(ctx, processPortRange, logsDir, addresses[types.ProcessManagerGrpcService], serverTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.ProcessManagerGrpcService)
 		return err
@@ -248,7 +246,7 @@ func start(c *cli.Context) (err error) {
 
 	// Start spdk server
 	if spdkEnabled {
-		spdkGRPCServer, spdkGRPCListener, err := setupSPDKGRPCServer(ctx, spdkPortRange, addresses[types.SpdkGrpcService])
+		spdkGRPCServer, spdkGRPCListener, err := setupSPDKGRPCServer(ctx, spdkPortRange, addresses[types.SpdkGrpcService], serverTLSConfig, clientTLSConfig)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to set up %s", types.SpdkGrpcService)
 			return err
@@ -311,6 +309,22 @@ func start(c *cli.Context) (err error) {
 	return nil
 }
 
+func loadTLSConfigsFromDir(tlsDir string) (serverTLSConfig, clientTLSConfig *tls.Config, err error) {
+	caFile := filepath.Join(tlsDir, types.TLSCAFile)
+	certFile := filepath.Join(tlsDir, types.TLSCertFile)
+	keyFile := filepath.Join(tlsDir, types.TLSKeyFile)
+
+	serverTLSConfig, err = util.LoadServerTLS(caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to initialize server TLS from %v", tlsDir)
+	}
+	clientTLSConfig, err = util.LoadClientTLS(caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to initialize client TLS from %v", tlsDir)
+	}
+	return serverTLSConfig, clientTLSConfig, nil
+}
+
 func getServiceAddresses(listen string) (addresses map[string]string, err error) {
 	host, port, err := net.SplitHostPort(listen)
 	if err != nil {
@@ -331,14 +345,30 @@ func getServiceAddresses(listen string) (addresses map[string]string, err error)
 	}, nil
 }
 
-func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
-	srv, err := disk.NewServer(ctx, spdkEnabled, spdkServiceAddress)
+// toClientAddress converts a server bind address to a local client dial address.
+// Intra-pod clients must dial the loopback interface, not the bind-all wildcard.
+func toClientAddress(serverAddr string) string {
+	host, port, err := net.SplitHostPort(serverAddr)
+	if err != nil {
+		return serverAddr
+	}
+	switch host {
+	case "0.0.0.0", "":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string, spdkEnabled bool, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
+	srv, err := disk.NewServer(ctx, spdkEnabled, spdkServiceAddress, clientTLSConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewDiskHealthCheckServer(srv)
 
-	grpcServer, rpcListener, err := util.NewServer(listen, nil,
+	grpcServer, rpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -355,19 +385,19 @@ func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string,
 	return grpcServer, rpcListener, nil
 }
 
-func setupSPDKGRPCServer(ctx context.Context, portRange, listen string) (*grpc.Server, net.Listener, error) {
+func setupSPDKGRPCServer(ctx context.Context, portRange, listen string, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
 	portStart, portEnd, err := util.ParsePortRange(portRange)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	srv, err := spdk.NewServer(ctx, portStart, portEnd)
+	srv, err := spdk.NewServer(ctx, portStart, portEnd, spdk.NewServiceClientFactory(clientTLSConfig))
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewSPDKHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, nil,
+	grpcServer, grpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -384,15 +414,15 @@ func setupSPDKGRPCServer(ctx context.Context, portRange, listen string) (*grpc.S
 	return grpcServer, grpcListener, nil
 }
 
-func setupProxyGRPCServer(ctx context.Context, logsDir, listen, diskServiceAddress, spdkServiceAddress string, tlsConfig *tls.Config) (*grpc.Server, net.Listener, error) {
+func setupProxyGRPCServer(ctx context.Context, logsDir, listen, spdkServiceAddress string, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
 	// TODO: skip proxy for replica instance manager pod
-	srv, err := proxy.NewProxy(ctx, logsDir, diskServiceAddress, spdkServiceAddress)
+	srv, err := proxy.NewProxy(ctx, logsDir, spdkServiceAddress, clientTLSConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewProxyHealthCheckServer(srv)
 
-	grpcProxyServer, grpcProxyListener, err := util.NewServer(listen, tlsConfig,
+	grpcProxyServer, grpcProxyListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -409,14 +439,14 @@ func setupProxyGRPCServer(ctx context.Context, logsDir, listen, diskServiceAddre
 	return grpcProxyServer, grpcProxyListener, nil
 }
 
-func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, listen string) (*process.Manager, *grpc.Server, net.Listener, error) {
+func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, listen string, tlsConfig *tls.Config) (*process.Manager, *grpc.Server, net.Listener, error) {
 	srv, err := process.NewManager(ctx, portRange, logsDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	hc := health.NewHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, nil,
+	grpcServer, grpcListener, err := util.NewServer(listen, tlsConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -433,14 +463,14 @@ func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, list
 	return srv, grpcServer, grpcListener, nil
 }
 
-func setupInstanceGRPCServer(ctx context.Context, logsDir, listen, processManagerServiceAddress, spdkServiceAddress string, tlsConfig *tls.Config, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
-	srv, err := instance.NewServer(ctx, logsDir, processManagerServiceAddress, spdkServiceAddress, spdkEnabled)
+func setupInstanceGRPCServer(ctx context.Context, logsDir, listen, processManagerServiceAddress, spdkServiceAddress string, serverTLSConfig, clientTLSConfig *tls.Config, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
+	srv, err := instance.NewServer(ctx, logsDir, processManagerServiceAddress, spdkServiceAddress, clientTLSConfig, spdkEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewInstanceHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, tlsConfig,
+	grpcServer, grpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,

--- a/app/cmd/start.go
+++ b/app/cmd/start.go
@@ -173,7 +173,7 @@ func start(c *cli.Command) (err error) {
 	if tlsDir != "" {
 		serverTLSConfig, clientTLSConfig, err = loadTLSConfigsFromDir(tlsDir)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to initialize TLS from %v; starting without TLS", tlsDir)
+			return err
 		}
 	}
 

--- a/app/cmd/start_test.go
+++ b/app/cmd/start_test.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/longhorn/longhorn-instance-manager/pkg/types"
+)
+
+// generateTestCertificates creates a self-signed CA and certificate pair for testing.
+func generateTestCertificates(t *testing.T) (caCertPEM, certPEM, keyPEM []byte) {
+	// Generate CA private key
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate CA key: %v", err)
+	}
+
+	// Create CA certificate template
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create CA certificate
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create CA certificate: %v", err)
+	}
+
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// Generate server private key
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate server key: %v", err)
+	}
+
+	// Create server certificate template
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Server"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:    []string{"localhost"},
+	}
+
+	// Create server certificate signed by CA
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create server certificate: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+
+	return caCertPEM, certPEM, keyPEM
+}
+
+// setupTestCerts creates a temporary directory with test certificate files.
+func setupTestCerts(t *testing.T) string {
+	certsDir := filepath.Join(t.TempDir(), "certs")
+	err := os.MkdirAll(certsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test certs directory: %v", err)
+	}
+
+	caCertPEM, certPEM, keyPEM := generateTestCertificates(t)
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSCAFile), caCertPEM, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test CA certificate: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSCertFile), certPEM, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test TLS certificate: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSKeyFile), keyPEM, 0600)
+	if err != nil {
+		t.Fatalf("Failed to write test TLS key: %v", err)
+	}
+
+	return certsDir
+}
+
+// loadTestTLSConfig loads test certificates and returns a *tls.Config.
+func loadTestTLSConfig(t *testing.T) *tls.Config {
+	certsDir := setupTestCerts(t)
+
+	caCertPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSCAFile))
+	if err != nil {
+		t.Fatalf("Failed to read CA certificate: %v", err)
+	}
+
+	certPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSCertFile))
+	if err != nil {
+		t.Fatalf("Failed to read TLS certificate: %v", err)
+	}
+
+	keyPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSKeyFile))
+	if err != nil {
+		t.Fatalf("Failed to read TLS key: %v", err)
+	}
+
+	// Create a minimal TLS config for testing
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(caCertPEM)
+	if !ok {
+		t.Fatal("Failed to append CA certificate to pool")
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create X509 key pair: %v", err)
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    certPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+
+	return tlsConfig
+}
+
+func TestLoadTLSConfigsFromDirFailsClosedWhenTLSDirIsInvalid(t *testing.T) {
+	serverTLSConfig, clientTLSConfig, err := loadTLSConfigsFromDir(filepath.Join(t.TempDir(), "missing"))
+
+	if err == nil {
+		t.Fatal("expected invalid TLS directory to fail")
+	}
+	if serverTLSConfig != nil {
+		t.Fatal("server TLS config must be nil when TLS initialization fails")
+	}
+	if clientTLSConfig != nil {
+		t.Fatal("client TLS config must be nil when TLS initialization fails")
+	}
+	if !strings.Contains(err.Error(), "failed to initialize server TLS") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadTLSConfigsFromDirReturnsValidConfigs(t *testing.T) {
+	tlsDir := setupTestCerts(t)
+
+	serverTLSConfig, clientTLSConfig, err := loadTLSConfigsFromDir(tlsDir)
+
+	if err != nil {
+		t.Fatalf("loadTLSConfigsFromDir should succeed: %v", err)
+	}
+	if serverTLSConfig == nil {
+		t.Fatal("server TLS config must not be nil")
+	}
+	if clientTLSConfig == nil {
+		t.Fatal("client TLS config must not be nil")
+	}
+}
+
+// TestSetupProcessManagerGRPCServer_WithTLS verifies ProcessManager server can be created with TLS config.
+func TestSetupProcessManagerGRPCServer_WithTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	portRange := "18500-18501"
+	logsDir := t.TempDir()
+	listen := "localhost:18500"
+
+	pm, server, listener, err := setupProcessManagerGRPCServer(ctx, portRange, logsDir, listen, tlsConfig)
+
+	if err != nil {
+		t.Fatalf("setupProcessManagerGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if pm == nil {
+		t.Fatal("ProcessManager should not be nil")
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupProcessManagerGRPCServer_WithoutTLS verifies ProcessManager server can be created without TLS (nil config).
+func TestSetupProcessManagerGRPCServer_WithoutTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	portRange := "18502-18503"
+	logsDir := t.TempDir()
+	listen := "localhost:18502"
+
+	pm, server, listener, err := setupProcessManagerGRPCServer(ctx, portRange, logsDir, listen, nil)
+
+	if err != nil {
+		t.Fatalf("setupProcessManagerGRPCServer should not return error without TLS config: %v", err)
+	}
+	if pm == nil {
+		t.Fatal("ProcessManager should not be nil")
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupDiskGRPCServer_WithTLS verifies DiskService server can be created with TLS config.
+func TestSetupDiskGRPCServer_WithTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	listen := "localhost:18504"
+	spdkServiceAddress := "localhost:18508" // dummy address, not actually used in this test
+	spdkEnabled := false
+
+	server, listener, err := setupDiskGRPCServer(ctx, listen, spdkServiceAddress, spdkEnabled, tlsConfig, tlsConfig)
+
+	if err != nil {
+		t.Fatalf("setupDiskGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupSPDKGRPCServer_WithTLS verifies SPDK server can be created with TLS config.
+// This test requires a running SPDK daemon (spdk_tgt) with socket at /var/tmp/spdk.sock.
+func TestSetupSPDKGRPCServer_WithTLS(t *testing.T) {
+	// Check if SPDK socket exists; skip if not available
+	spdkSocket := "/var/tmp/spdk.sock"
+	if _, err := os.Stat(spdkSocket); os.IsNotExist(err) {
+		t.Skipf("SPDK daemon socket not found at %s; skipping SPDK server test", spdkSocket)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	portRange := "18506-18507"
+	listen := "localhost:18506"
+
+	server, listener, err := setupSPDKGRPCServer(ctx, portRange, listen, tlsConfig, nil)
+
+	if err != nil {
+		t.Fatalf("setupSPDKGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13305

#### What this PR does / why we need it:

Previously, a bad or missing TLS directory was only logged as a warning and the daemon continued in plaintext mode. With --tls-dir explicitly configured this is an operator error that should not be silently ignored; refuse to start and surface the error instead.

#### Special notes for your reviewer:

#### Additional documentation or context
