### PR TITLE
feat(security): rotatable TLS client

### DIFF
--- a/app/cmd/start.go
+++ b/app/cmd/start.go
@@ -165,21 +165,17 @@ func start(c *cli.Context) (err error) {
 		}
 	}
 
-	// setup tls config
-	var tlsConfig *tls.Config
+	var serverTLSConfig *tls.Config
+	var clientTLSConfig *tls.Config
 	tlsDir := c.GlobalString("tls-dir")
 	if tlsDir != "" {
-		tlsConfig, err = util.LoadServerTLS(
-			filepath.Join(tlsDir, "ca.crt"),
-			filepath.Join(tlsDir, "tls.crt"),
-			filepath.Join(tlsDir, "tls.key"),
-			"longhorn-backend.longhorn-system")
+		serverTLSConfig, clientTLSConfig, err = loadTLSConfigsFromDir(tlsDir)
 		if err != nil {
-			logrus.WithError(err).Warnf("Failed to add TLS key pair from %v", tlsDir)
+			logrus.WithError(err).Warnf("Failed to initialize TLS from %v; starting without TLS", tlsDir)
 		}
 	}
 
-	if tlsConfig != nil {
+	if serverTLSConfig != nil {
 		logrus.Info("Creating gRPC server with mtls auth")
 	} else {
 		logrus.Info("Creating gRPC server with no auth")
@@ -207,8 +203,10 @@ func start(c *cli.Context) (err error) {
 	servers := map[string]*grpc.Server{}
 	listeners := map[string]net.Listener{}
 
+	spdkClientAddr := toClientAddress(addresses[types.SpdkGrpcService])
+
 	// Start disk server
-	diskGRPCServer, diskGRPCListener, err := setupDiskGRPCServer(ctx, addresses[types.DiskGrpcService], addresses[types.SpdkGrpcService], spdkEnabled)
+	diskGRPCServer, diskGRPCListener, err := setupDiskGRPCServer(ctx, addresses[types.DiskGrpcService], spdkClientAddr, spdkEnabled, serverTLSConfig, clientTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to setup %s", types.DiskGrpcService)
 		return err
@@ -218,8 +216,8 @@ func start(c *cli.Context) (err error) {
 
 	// Start instance server
 	instanceGRPCServer, instanceRPCListener, err := setupInstanceGRPCServer(ctx, logsDir,
-		addresses[types.InstanceGrpcService], addresses[types.ProcessManagerGrpcService],
-		addresses[types.SpdkGrpcService], tlsConfig, spdkEnabled)
+		addresses[types.InstanceGrpcService], toClientAddress(addresses[types.ProcessManagerGrpcService]),
+		spdkClientAddr, serverTLSConfig, clientTLSConfig, spdkEnabled)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.InstanceGrpcService)
 		return err
@@ -229,7 +227,7 @@ func start(c *cli.Context) (err error) {
 
 	// Start proxy server
 	proxyGRPCServer, proxyGRPCListener, err := setupProxyGRPCServer(ctx, logsDir,
-		addresses[types.ProxyGRPCService], addresses[types.DiskGrpcService], addresses[types.SpdkGrpcService], tlsConfig)
+		addresses[types.ProxyGRPCService], spdkClientAddr, serverTLSConfig, clientTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.ProxyGRPCService)
 		return err
@@ -238,7 +236,7 @@ func start(c *cli.Context) (err error) {
 	listeners[types.ProxyGRPCService] = proxyGRPCListener
 
 	// Start process-manager server
-	pm, pmGRPCServer, pmGRPCListener, err := setupProcessManagerGRPCServer(ctx, processPortRange, logsDir, addresses[types.ProcessManagerGrpcService])
+	pm, pmGRPCServer, pmGRPCListener, err := setupProcessManagerGRPCServer(ctx, processPortRange, logsDir, addresses[types.ProcessManagerGrpcService], serverTLSConfig)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to set up %s", types.ProcessManagerGrpcService)
 		return err
@@ -248,7 +246,7 @@ func start(c *cli.Context) (err error) {
 
 	// Start spdk server
 	if spdkEnabled {
-		spdkGRPCServer, spdkGRPCListener, err := setupSPDKGRPCServer(ctx, spdkPortRange, addresses[types.SpdkGrpcService])
+		spdkGRPCServer, spdkGRPCListener, err := setupSPDKGRPCServer(ctx, spdkPortRange, addresses[types.SpdkGrpcService], serverTLSConfig, clientTLSConfig)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to set up %s", types.SpdkGrpcService)
 			return err
@@ -311,6 +309,22 @@ func start(c *cli.Context) (err error) {
 	return nil
 }
 
+func loadTLSConfigsFromDir(tlsDir string) (serverTLSConfig, clientTLSConfig *tls.Config, err error) {
+	caFile := filepath.Join(tlsDir, types.TLSCAFile)
+	certFile := filepath.Join(tlsDir, types.TLSCertFile)
+	keyFile := filepath.Join(tlsDir, types.TLSKeyFile)
+
+	serverTLSConfig, err = util.NewReloadableServerTLS(caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to initialize reloadable server TLS from %v", tlsDir)
+	}
+	clientTLSConfig, err = util.NewReloadableClientTLS(caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to initialize reloadable client TLS from %v", tlsDir)
+	}
+	return serverTLSConfig, clientTLSConfig, nil
+}
+
 func getServiceAddresses(listen string) (addresses map[string]string, err error) {
 	host, port, err := net.SplitHostPort(listen)
 	if err != nil {
@@ -331,14 +345,30 @@ func getServiceAddresses(listen string) (addresses map[string]string, err error)
 	}, nil
 }
 
-func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
-	srv, err := disk.NewServer(ctx, spdkEnabled, spdkServiceAddress)
+// toClientAddress converts a server bind address to a local client dial address.
+// Intra-pod clients must dial the loopback interface, not the bind-all wildcard.
+func toClientAddress(serverAddr string) string {
+	host, port, err := net.SplitHostPort(serverAddr)
+	if err != nil {
+		return serverAddr
+	}
+	switch host {
+	case "0.0.0.0", "":
+		host = "127.0.0.1"
+	case "::":
+		host = "::1"
+	}
+	return net.JoinHostPort(host, port)
+}
+
+func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string, spdkEnabled bool, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
+	srv, err := disk.NewServer(ctx, spdkEnabled, spdkServiceAddress, clientTLSConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewDiskHealthCheckServer(srv)
 
-	grpcServer, rpcListener, err := util.NewServer(listen, nil,
+	grpcServer, rpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -355,19 +385,19 @@ func setupDiskGRPCServer(ctx context.Context, listen, spdkServiceAddress string,
 	return grpcServer, rpcListener, nil
 }
 
-func setupSPDKGRPCServer(ctx context.Context, portRange, listen string) (*grpc.Server, net.Listener, error) {
+func setupSPDKGRPCServer(ctx context.Context, portRange, listen string, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
 	portStart, portEnd, err := util.ParsePortRange(portRange)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	srv, err := spdk.NewServer(ctx, portStart, portEnd)
+	srv, err := spdk.NewServer(ctx, portStart, portEnd, spdk.NewServiceClientFactory(clientTLSConfig))
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewSPDKHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, nil,
+	grpcServer, grpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -384,15 +414,15 @@ func setupSPDKGRPCServer(ctx context.Context, portRange, listen string) (*grpc.S
 	return grpcServer, grpcListener, nil
 }
 
-func setupProxyGRPCServer(ctx context.Context, logsDir, listen, diskServiceAddress, spdkServiceAddress string, tlsConfig *tls.Config) (*grpc.Server, net.Listener, error) {
+func setupProxyGRPCServer(ctx context.Context, logsDir, listen, spdkServiceAddress string, serverTLSConfig, clientTLSConfig *tls.Config) (*grpc.Server, net.Listener, error) {
 	// TODO: skip proxy for replica instance manager pod
-	srv, err := proxy.NewProxy(ctx, logsDir, diskServiceAddress, spdkServiceAddress)
+	srv, err := proxy.NewProxy(ctx, logsDir, spdkServiceAddress, clientTLSConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewProxyHealthCheckServer(srv)
 
-	grpcProxyServer, grpcProxyListener, err := util.NewServer(listen, tlsConfig,
+	grpcProxyServer, grpcProxyListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -409,14 +439,14 @@ func setupProxyGRPCServer(ctx context.Context, logsDir, listen, diskServiceAddre
 	return grpcProxyServer, grpcProxyListener, nil
 }
 
-func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, listen string) (*process.Manager, *grpc.Server, net.Listener, error) {
+func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, listen string, tlsConfig *tls.Config) (*process.Manager, *grpc.Server, net.Listener, error) {
 	srv, err := process.NewManager(ctx, portRange, logsDir)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 	hc := health.NewHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, nil,
+	grpcServer, grpcListener, err := util.NewServer(listen, tlsConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,
@@ -433,14 +463,14 @@ func setupProcessManagerGRPCServer(ctx context.Context, portRange, logsDir, list
 	return srv, grpcServer, grpcListener, nil
 }
 
-func setupInstanceGRPCServer(ctx context.Context, logsDir, listen, processManagerServiceAddress, spdkServiceAddress string, tlsConfig *tls.Config, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
-	srv, err := instance.NewServer(ctx, logsDir, processManagerServiceAddress, spdkServiceAddress, spdkEnabled)
+func setupInstanceGRPCServer(ctx context.Context, logsDir, listen, processManagerServiceAddress, spdkServiceAddress string, serverTLSConfig, clientTLSConfig *tls.Config, spdkEnabled bool) (*grpc.Server, net.Listener, error) {
+	srv, err := instance.NewServer(ctx, logsDir, processManagerServiceAddress, spdkServiceAddress, clientTLSConfig, spdkEnabled)
 	if err != nil {
 		return nil, nil, err
 	}
 	hc := health.NewInstanceHealthCheckServer(srv)
 
-	grpcServer, grpcListener, err := util.NewServer(listen, tlsConfig,
+	grpcServer, grpcListener, err := util.NewServer(listen, serverTLSConfig,
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			MinTime:             10 * time.Second,
 			PermitWithoutStream: true,

--- a/app/cmd/start_test.go
+++ b/app/cmd/start_test.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/longhorn/longhorn-instance-manager/pkg/types"
+)
+
+// generateTestCertificates creates a self-signed CA and certificate pair for testing.
+func generateTestCertificates(t *testing.T) (caCertPEM, certPEM, keyPEM []byte) {
+	// Generate CA private key
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate CA key: %v", err)
+	}
+
+	// Create CA certificate template
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	// Create CA certificate
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create CA certificate: %v", err)
+	}
+
+	caCertPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+
+	// Generate server private key
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate server key: %v", err)
+	}
+
+	// Create server certificate template
+	serverTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Server"},
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:    []string{"localhost"},
+	}
+
+	// Create server certificate signed by CA
+	serverCertDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("Failed to create server certificate: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverCertDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+
+	return caCertPEM, certPEM, keyPEM
+}
+
+// setupTestCerts creates a temporary directory with test certificate files.
+func setupTestCerts(t *testing.T) string {
+	certsDir := filepath.Join(t.TempDir(), "certs")
+	err := os.MkdirAll(certsDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test certs directory: %v", err)
+	}
+
+	caCertPEM, certPEM, keyPEM := generateTestCertificates(t)
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSCAFile), caCertPEM, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test CA certificate: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSCertFile), certPEM, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test TLS certificate: %v", err)
+	}
+
+	err = os.WriteFile(filepath.Join(certsDir, types.TLSKeyFile), keyPEM, 0600)
+	if err != nil {
+		t.Fatalf("Failed to write test TLS key: %v", err)
+	}
+
+	return certsDir
+}
+
+// loadTestTLSConfig loads test certificates and returns a *tls.Config.
+func loadTestTLSConfig(t *testing.T) *tls.Config {
+	certsDir := setupTestCerts(t)
+
+	caCertPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSCAFile))
+	if err != nil {
+		t.Fatalf("Failed to read CA certificate: %v", err)
+	}
+
+	certPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSCertFile))
+	if err != nil {
+		t.Fatalf("Failed to read TLS certificate: %v", err)
+	}
+
+	keyPEM, err := os.ReadFile(filepath.Join(certsDir, types.TLSKeyFile))
+	if err != nil {
+		t.Fatalf("Failed to read TLS key: %v", err)
+	}
+
+	// Create a minimal TLS config for testing
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(caCertPEM)
+	if !ok {
+		t.Fatal("Failed to append CA certificate to pool")
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("Failed to create X509 key pair: %v", err)
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion:   tls.VersionTLS13,
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    certPool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+	}
+
+	return tlsConfig
+}
+
+func TestLoadTLSConfigsFromDirReturnsErrorForInvalidDir(t *testing.T) {
+	serverTLSConfig, clientTLSConfig, err := loadTLSConfigsFromDir(filepath.Join(t.TempDir(), "missing"))
+
+	if err == nil {
+		t.Fatal("expected invalid TLS directory to fail")
+	}
+	if serverTLSConfig != nil {
+		t.Fatal("server TLS config must be nil when TLS initialization fails")
+	}
+	if clientTLSConfig != nil {
+		t.Fatal("client TLS config must be nil when TLS initialization fails")
+	}
+	if !strings.Contains(err.Error(), "failed to initialize reloadable server TLS") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadTLSConfigsFromDirReturnsReloadableConfigs(t *testing.T) {
+	tlsDir := setupTestCerts(t)
+
+	serverTLSConfig, clientTLSConfig, err := loadTLSConfigsFromDir(tlsDir)
+
+	if err != nil {
+		t.Fatalf("loadTLSConfigsFromDir should succeed: %v", err)
+	}
+	if serverTLSConfig == nil || serverTLSConfig.GetConfigForClient == nil {
+		t.Fatal("server TLS config must be reloadable")
+	}
+	if clientTLSConfig == nil || clientTLSConfig.GetClientCertificate == nil || clientTLSConfig.VerifyConnection == nil {
+		t.Fatal("client TLS config must be reloadable")
+	}
+}
+
+// TestSetupProcessManagerGRPCServer_WithTLS verifies ProcessManager server can be created with TLS config.
+func TestSetupProcessManagerGRPCServer_WithTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	portRange := "18500-18501"
+	logsDir := t.TempDir()
+	listen := "localhost:18500"
+
+	pm, server, listener, err := setupProcessManagerGRPCServer(ctx, portRange, logsDir, listen, tlsConfig)
+
+	if err != nil {
+		t.Fatalf("setupProcessManagerGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if pm == nil {
+		t.Fatal("ProcessManager should not be nil")
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupProcessManagerGRPCServer_WithoutTLS verifies ProcessManager server can be created without TLS (nil config).
+func TestSetupProcessManagerGRPCServer_WithoutTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	portRange := "18502-18503"
+	logsDir := t.TempDir()
+	listen := "localhost:18502"
+
+	pm, server, listener, err := setupProcessManagerGRPCServer(ctx, portRange, logsDir, listen, nil)
+
+	if err != nil {
+		t.Fatalf("setupProcessManagerGRPCServer should not return error without TLS config: %v", err)
+	}
+	if pm == nil {
+		t.Fatal("ProcessManager should not be nil")
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupDiskGRPCServer_WithTLS verifies DiskService server can be created with TLS config.
+func TestSetupDiskGRPCServer_WithTLS(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	listen := "localhost:18504"
+	spdkServiceAddress := "localhost:18508" // dummy address, not actually used in this test
+	spdkEnabled := false
+
+	server, listener, err := setupDiskGRPCServer(ctx, listen, spdkServiceAddress, spdkEnabled, tlsConfig, tlsConfig)
+
+	if err != nil {
+		t.Fatalf("setupDiskGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}
+
+// TestSetupSPDKGRPCServer_WithTLS verifies SPDK server can be created with TLS config.
+// This test requires a running SPDK daemon (spdk_tgt) with socket at /var/tmp/spdk.sock.
+func TestSetupSPDKGRPCServer_WithTLS(t *testing.T) {
+	// Check if SPDK socket exists; skip if not available
+	spdkSocket := "/var/tmp/spdk.sock"
+	if _, err := os.Stat(spdkSocket); os.IsNotExist(err) {
+		t.Skipf("SPDK daemon socket not found at %s; skipping SPDK server test", spdkSocket)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tlsConfig := loadTestTLSConfig(t)
+	portRange := "18506-18507"
+	listen := "localhost:18506"
+
+	server, listener, err := setupSPDKGRPCServer(ctx, portRange, listen, tlsConfig, nil)
+
+	if err != nil {
+		t.Fatalf("setupSPDKGRPCServer should not return error with valid TLS config: %v", err)
+	}
+	if server == nil {
+		t.Fatal("gRPC server should not be nil")
+	}
+	if listener == nil {
+		t.Fatal("Listener should not be nil")
+	}
+
+	// Clean up resources
+	defer func() {
+		server.Stop()
+		if err := listener.Close(); err != nil {
+			t.Logf("Failed to close listener: %v", err)
+		}
+	}()
+}

--- a/pkg/client/disk.go
+++ b/pkg/client/disk.go
@@ -77,7 +77,7 @@ func NewDiskServiceClient(ctx context.Context, ctxCancel context.CancelFunc, ser
 
 // NewDiskServiceClientWithTLS creates a new DiskServiceClient with TLS
 func NewDiskServiceClientWithTLS(ctx context.Context, ctxCancel context.CancelFunc, serviceURL, caFile, certFile, keyFile, peerName string) (*DiskServiceClient, error) {
-	tlsConfig, err := util.LoadClientTLS(caFile, certFile, keyFile, peerName)
+	tlsConfig, err := util.NewReloadableClientTLS(caFile, certFile, keyFile, peerName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load tls key pair from file")
 	}

--- a/pkg/client/instance.go
+++ b/pkg/client/instance.go
@@ -79,7 +79,7 @@ func NewInstanceServiceClient(ctx context.Context, ctxCancel context.CancelFunc,
 }
 
 func NewInstanceServiceClientWithTLS(ctx context.Context, ctxCancel context.CancelFunc, serviceURL, caFile, certFile, keyFile, peerName string) (*InstanceServiceClient, error) {
-	tlsConfig, err := util.LoadClientTLS(caFile, certFile, keyFile, peerName)
+	tlsConfig, err := util.NewReloadableClientTLS(caFile, certFile, keyFile, peerName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load tls key pair from file")
 	}

--- a/pkg/client/process_manager.go
+++ b/pkg/client/process_manager.go
@@ -80,7 +80,7 @@ func NewProcessManagerClient(ctx context.Context, ctxCancel context.CancelFunc, 
 }
 
 func NewProcessManagerClientWithTLS(ctx context.Context, ctxCancel context.CancelFunc, serviceURL, caFile, certFile, keyFile, peerName string) (*ProcessManagerClient, error) {
-	tlsConfig, err := util.LoadClientTLS(caFile, certFile, keyFile, peerName)
+	tlsConfig, err := util.NewReloadableClientTLS(caFile, certFile, keyFile, peerName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load tls key pair from file")
 	}

--- a/pkg/client/proxy.go
+++ b/pkg/client/proxy.go
@@ -93,7 +93,7 @@ func NewProxyClient(ctx context.Context, ctxCancel context.CancelFunc, address s
 }
 
 func NewProxyClientWithTLS(ctx context.Context, ctxCancel context.CancelFunc, address string, port int, caFile, certFile, keyFile, peerName string) (*ProxyClient, error) {
-	tlsConfig, err := util.LoadClientTLS(caFile, certFile, keyFile, peerName)
+	tlsConfig, err := util.NewReloadableClientTLS(caFile, certFile, keyFile, peerName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load tls key pair from file")
 	}

--- a/pkg/client/tls_test.go
+++ b/pkg/client/tls_test.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/longhorn/longhorn-instance-manager/pkg/types"
+)
+
+func writeClientTestCerts(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+
+	clientKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate client key: %v", err)
+	}
+	clientTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: types.TLSPeerName},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{types.TLSPeerName},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTmpl, caCert, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create client cert: %v", err)
+	}
+
+	files := map[string][]byte{
+		types.TLSCAFile:   pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		types.TLSCertFile: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		types.TLSKeyFile:  pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(clientKey)}),
+	}
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), content, 0600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+func assertReloadableTLSConfig(t *testing.T, tlsConfig *tls.Config) {
+	t.Helper()
+	if tlsConfig == nil {
+		t.Fatal("TLS config must not be nil")
+	}
+	if tlsConfig.GetClientCertificate == nil {
+		t.Fatal("TLS config must reload client certificates")
+	}
+	if tlsConfig.VerifyConnection == nil {
+		t.Fatal("TLS config must verify server certificates with reloadable CA data")
+	}
+}
+
+func TestWithTLSConstructorsUseReloadableClientTLS(t *testing.T) {
+	tlsDir := writeClientTestCerts(t)
+	caFile := filepath.Join(tlsDir, types.TLSCAFile)
+	certFile := filepath.Join(tlsDir, types.TLSCertFile)
+	keyFile := filepath.Join(tlsDir, types.TLSKeyFile)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	diskClient, err := NewDiskServiceClientWithTLS(ctx, cancel, "tcp://127.0.0.1:1", caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		t.Fatalf("NewDiskServiceClientWithTLS: %v", err)
+	}
+	defer diskClient.Close()
+	assertReloadableTLSConfig(t, diskClient.tlsConfig)
+
+	instanceClient, err := NewInstanceServiceClientWithTLS(ctx, cancel, "tcp://127.0.0.1:1", caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		t.Fatalf("NewInstanceServiceClientWithTLS: %v", err)
+	}
+	defer instanceClient.Close()
+	assertReloadableTLSConfig(t, instanceClient.tlsConfig)
+
+	processClient, err := NewProcessManagerClientWithTLS(ctx, cancel, "tcp://127.0.0.1:1", caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		t.Fatalf("NewProcessManagerClientWithTLS: %v", err)
+	}
+	defer processClient.Close()
+	assertReloadableTLSConfig(t, processClient.tlsConfig)
+
+	proxyClient, err := NewProxyClientWithTLS(ctx, cancel, "127.0.0.1", 1, caFile, certFile, keyFile, types.TLSPeerName)
+	if err != nil {
+		t.Fatalf("NewProxyClientWithTLS: %v", err)
+	}
+	defer proxyClient.Close()
+	assertReloadableTLSConfig(t, proxyClient.tlsConfig)
+}

--- a/pkg/util/grpcutil.go
+++ b/pkg/util/grpcutil.go
@@ -225,6 +225,28 @@ func loadCertificate(caFile, certFile, keyFile string) (certPool *x509.CertPool,
 	return
 }
 
+// NewReloadableServerTLS returns a *tls.Config that reloads certificates from
+// disk on each incoming TLS handshake if the files have changed since the last
+// successful load. On failure the last known good snapshot is retained.
+func NewReloadableServerTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, error) {
+	p, err := newTLSConfigProvider(caFile, certFile, keyFile, peerName)
+	if err != nil {
+		return nil, err
+	}
+	return p.ServerConfig(), nil
+}
+
+// NewReloadableClientTLS returns a *tls.Config that reloads the client certificate
+// and CA pool on each outgoing TLS handshake if the files have changed since the
+// last successful load. On failure the last known good snapshot is retained.
+func NewReloadableClientTLS(caFile, certFile, keyFile, peerName string) (*tls.Config, error) {
+	p, err := newTLSConfigProvider(caFile, certFile, keyFile, peerName)
+	if err != nil {
+		return nil, err
+	}
+	return p.ClientConfig(), nil
+}
+
 // parseEndpoint splits ep string into proto and address
 // the supported protocols are "tcp" and "unix" unsupported protocols will return error
 // if the ep (url) does not contain a protocol, we return "tcp" for backwards compatibility

--- a/pkg/util/tls.go
+++ b/pkg/util/tls.go
@@ -1,0 +1,207 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type tlsSnapshot struct {
+	cert     tls.Certificate
+	certPool *x509.CertPool
+}
+
+// TLSConfigProvider loads TLS credentials from disk and reloads them lazily on each
+// new TLS handshake if any of the three cert files have changed since the last
+// successful load. On reload failure the last known good snapshot is retained
+// and a warning is logged - the provider never downgrades to plaintext.
+type TLSConfigProvider struct {
+	caFile   string
+	certFile string
+	keyFile  string
+	peerName string
+
+	log      *logrus.Entry
+	mu       sync.RWMutex
+	snapshot *tlsSnapshot
+	mtimes   [3]time.Time // [caFile, certFile, keyFile]
+}
+
+func newTLSConfigProvider(caFile, certFile, keyFile, peerName string) (*TLSConfigProvider, error) {
+	p := &TLSConfigProvider{
+		caFile:   caFile,
+		certFile: certFile,
+		keyFile:  keyFile,
+		peerName: peerName,
+		log: logrus.WithFields(logrus.Fields{
+			"caFile":   caFile,
+			"certFile": certFile,
+			"keyFile":  keyFile,
+			"peerName": peerName,
+		}),
+	}
+	snap, mtimes, err := p.doLoad()
+	if err != nil {
+		return nil, err
+	}
+	p.snapshot = snap
+	p.mtimes = mtimes
+	return p, nil
+}
+
+func (p *TLSConfigProvider) statFiles() ([3]time.Time, error) {
+	var mtimes [3]time.Time
+	for i, f := range []string{p.caFile, p.certFile, p.keyFile} {
+		fi, err := os.Stat(f)
+		if err != nil {
+			return mtimes, fmt.Errorf("stat %s: %w", f, err)
+		}
+		mtimes[i] = fi.ModTime()
+	}
+	return mtimes, nil
+}
+
+func (p *TLSConfigProvider) doLoad() (*tlsSnapshot, [3]time.Time, error) {
+	mtimes, err := p.statFiles()
+	if err != nil {
+		return nil, mtimes, err
+	}
+
+	caCert, err := os.ReadFile(p.caFile)
+	if err != nil {
+		return nil, mtimes, errors.Wrap(err, "read CA file")
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(caCert); !ok {
+		return nil, mtimes, errors.New("failed to parse CA certificate")
+	}
+
+	cert, err := tls.LoadX509KeyPair(p.certFile, p.keyFile)
+	if err != nil {
+		return nil, mtimes, errors.Wrap(err, "load key pair")
+	}
+
+	return &tlsSnapshot{cert: cert, certPool: certPool}, mtimes, nil
+}
+
+// maybeReload stats the cert files and reloads the snapshot if any file has
+// changed. On failure the previous snapshot is retained and a warning is logged.
+func (p *TLSConfigProvider) maybeReload() {
+	newMtimes, err := p.statFiles()
+	if err != nil {
+		p.log.WithError(err).Warn("TLSConfigProvider: cannot stat cert files; keeping last known good certificates")
+		return
+	}
+
+	p.mu.RLock()
+	unchanged := newMtimes == p.mtimes
+	p.mu.RUnlock()
+	if unchanged {
+		return
+	}
+
+	snap, mtimes, err := p.doLoad()
+	if err != nil {
+		p.log.WithError(err).Warn("TLSConfigProvider: certificate reload failed; keeping last known good certificates")
+		return
+	}
+
+	p.mu.Lock()
+	p.snapshot = snap
+	p.mtimes = mtimes
+	p.mu.Unlock()
+	p.log.Info("TLSConfigProvider: TLS certificates reloaded successfully")
+}
+
+// ServerConfig returns a *tls.Config that calls maybeReload on every incoming
+// TLS handshake so the server always uses the freshest available certificates.
+func (p *TLSConfigProvider) ServerConfig() *tls.Config {
+	return &tls.Config{
+		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+			if info == nil {
+				return nil, errors.New("nil ClientHelloInfo")
+			}
+			p.maybeReload()
+			p.mu.RLock()
+			snap := p.snapshot
+			p.mu.RUnlock()
+			return serverConfigFromSnapshot(snap, p.peerName), nil
+		},
+	}
+}
+
+// ClientConfig returns a *tls.Config that reloads the client certificate and CA
+// pool lazily on each outgoing TLS handshake. InsecureSkipVerify is set to true
+// so that Go's built-in static server verification is bypassed; VerifyConnection
+// performs equivalent verification using the latest CA pool from the snapshot.
+func (p *TLSConfigProvider) ClientConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		Renegotiation:      tls.RenegotiateNever,
+		ServerName:         p.peerName,
+		InsecureSkipVerify: true, // server cert verified via VerifyConnection below
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			p.maybeReload()
+			p.mu.RLock()
+			cert := p.snapshot.cert
+			p.mu.RUnlock()
+			return &cert, nil
+		},
+		VerifyConnection: func(cs tls.ConnectionState) error {
+			p.mu.RLock()
+			certPool := p.snapshot.certPool
+			p.mu.RUnlock()
+			if len(cs.PeerCertificates) == 0 {
+				return errors.New("server presented no certificate")
+			}
+			opts := x509.VerifyOptions{
+				Roots:         certPool,
+				DNSName:       p.peerName,
+				Intermediates: x509.NewCertPool(),
+			}
+			for _, c := range cs.PeerCertificates[1:] {
+				opts.Intermediates.AddCert(c)
+			}
+			_, err := cs.PeerCertificates[0].Verify(opts)
+			return err
+		},
+	}
+}
+
+func serverConfigFromSnapshot(snap *tlsSnapshot, peerName string) *tls.Config {
+	cfg := &tls.Config{
+		MinVersion:    tls.VersionTLS13,
+		Renegotiation: tls.RenegotiateNever,
+		Certificates:  []tls.Certificate{snap.cert},
+		ClientCAs:     snap.certPool,
+		VerifyPeerCertificate: func(_ [][]byte, verifiedChains [][]*x509.Certificate) error {
+			if peerName == "" {
+				return nil
+			}
+			if len(verifiedChains) == 0 || len(verifiedChains[0]) == 0 {
+				return errors.New("no valid certificate chain")
+			}
+			peer := verifiedChains[0][0]
+			for _, name := range peer.DNSNames {
+				if name == peerName {
+					return nil
+				}
+			}
+			if peer.Subject.CommonName == peerName {
+				return nil
+			}
+			return fmt.Errorf("certificate is not signed for %q hostname", peerName)
+		},
+	}
+	if peerName != "" {
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+	return cfg
+}

--- a/pkg/util/tls_test.go
+++ b/pkg/util/tls_test.go
@@ -1,0 +1,233 @@
+package util
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func generateSelfSignedCert(t *testing.T) (caPEM, certPEM, keyPEM []byte) {
+	t.Helper()
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	serverTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "test-server"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		DNSNames:     []string{"test-server"},
+	}
+	serverDER, err := x509.CreateCertificate(rand.Reader, serverTmpl, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create server cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: serverDER})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	return
+}
+
+func writeCerts(t *testing.T, dir string, caPEM, certPEM, keyPEM []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "ca.crt"), caPEM, 0644); err != nil {
+		t.Fatalf("write ca.crt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), certPEM, 0644); err != nil {
+		t.Fatalf("write tls.crt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tls.key"), keyPEM, 0600); err != nil {
+		t.Fatalf("write tls.key: %v", err)
+	}
+}
+
+func TestTLSConfigProvider_InitialLoad(t *testing.T) {
+	dir := t.TempDir()
+	caPEM, certPEM, keyPEM := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM, certPEM, keyPEM)
+
+	p, err := newTLSConfigProvider(
+		filepath.Join(dir, "ca.crt"),
+		filepath.Join(dir, "tls.crt"),
+		filepath.Join(dir, "tls.key"),
+		"test-server",
+	)
+	if err != nil {
+		t.Fatalf("newTLSConfigProvider: %v", err)
+	}
+	if p.snapshot == nil {
+		t.Fatal("snapshot must not be nil after initial load")
+	}
+	if p.snapshot.certPool == nil {
+		t.Fatal("certPool must not be nil after initial load")
+	}
+}
+
+func TestTLSConfigProvider_ReloadOnChange(t *testing.T) {
+	dir := t.TempDir()
+	caPEM, certPEM, keyPEM := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM, certPEM, keyPEM)
+
+	p, err := newTLSConfigProvider(
+		filepath.Join(dir, "ca.crt"),
+		filepath.Join(dir, "tls.crt"),
+		filepath.Join(dir, "tls.key"),
+		"test-server",
+	)
+	if err != nil {
+		t.Fatalf("newTLSConfigProvider: %v", err)
+	}
+	oldSnap := p.snapshot
+	oldCertDER := make([]byte, len(oldSnap.cert.Certificate[0]))
+	copy(oldCertDER, oldSnap.cert.Certificate[0])
+
+	caPEM2, certPEM2, keyPEM2 := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM2, certPEM2, keyPEM2)
+	// Advance mtime so statFiles detects a change.
+	future := time.Now().Add(2 * time.Second)
+	for _, f := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := os.Chtimes(filepath.Join(dir, f), future, future); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
+	p.maybeReload()
+
+	if p.snapshot == oldSnap {
+		t.Error("snapshot must be replaced after file change")
+	}
+	newCertDER := p.snapshot.cert.Certificate[0]
+	if string(newCertDER) == string(oldCertDER) {
+		t.Error("cert content must differ after reload with new certificates")
+	}
+}
+
+func TestTLSConfigProvider_LastKnownGoodOnBadReload(t *testing.T) {
+	dir := t.TempDir()
+	caPEM, certPEM, keyPEM := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM, certPEM, keyPEM)
+
+	p, err := newTLSConfigProvider(
+		filepath.Join(dir, "ca.crt"),
+		filepath.Join(dir, "tls.crt"),
+		filepath.Join(dir, "tls.key"),
+		"test-server",
+	)
+	if err != nil {
+		t.Fatalf("newTLSConfigProvider: %v", err)
+	}
+	oldSnap := p.snapshot
+
+	// Corrupt the cert file and advance mtime so maybeReload attempts a reload.
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), []byte("not a valid cert"), 0644); err != nil {
+		t.Fatalf("corrupt cert file: %v", err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	for _, f := range []string{"ca.crt", "tls.crt", "tls.key"} {
+		if err := os.Chtimes(filepath.Join(dir, f), future, future); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+	}
+
+	p.maybeReload()
+
+	if p.snapshot != oldSnap {
+		t.Error("snapshot must be retained (last known good) when reload fails")
+	}
+}
+
+func TestTLSConfigProvider_ServerConfig(t *testing.T) {
+	dir := t.TempDir()
+	caPEM, certPEM, keyPEM := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM, certPEM, keyPEM)
+
+	p, err := newTLSConfigProvider(
+		filepath.Join(dir, "ca.crt"),
+		filepath.Join(dir, "tls.crt"),
+		filepath.Join(dir, "tls.key"),
+		"test-server",
+	)
+	if err != nil {
+		t.Fatalf("newTLSConfigProvider: %v", err)
+	}
+	cfg := p.ServerConfig()
+	if cfg == nil {
+		t.Fatal("ServerConfig must not return nil")
+	}
+	if cfg.GetConfigForClient == nil {
+		t.Error("ServerConfig must set GetConfigForClient")
+	}
+	inner, err := cfg.GetConfigForClient(&tls.ClientHelloInfo{})
+	if err != nil {
+		t.Fatalf("GetConfigForClient: %v", err)
+	}
+	if len(inner.Certificates) == 0 {
+		t.Error("inner config must include the server certificate")
+	}
+}
+
+func TestTLSConfigProvider_ClientConfig(t *testing.T) {
+	dir := t.TempDir()
+	caPEM, certPEM, keyPEM := generateSelfSignedCert(t)
+	writeCerts(t, dir, caPEM, certPEM, keyPEM)
+
+	p, err := newTLSConfigProvider(
+		filepath.Join(dir, "ca.crt"),
+		filepath.Join(dir, "tls.crt"),
+		filepath.Join(dir, "tls.key"),
+		"test-server",
+	)
+	if err != nil {
+		t.Fatalf("newTLSConfigProvider: %v", err)
+	}
+	cfg := p.ClientConfig()
+	if cfg == nil {
+		t.Fatal("ClientConfig must not return nil")
+	}
+	if cfg.GetClientCertificate == nil {
+		t.Error("ClientConfig must set GetClientCertificate")
+	}
+	if cfg.VerifyConnection == nil {
+		t.Error("ClientConfig must set VerifyConnection")
+	}
+	cert, err := cfg.GetClientCertificate(nil)
+	if err != nil {
+		t.Fatalf("GetClientCertificate: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Error("GetClientCertificate must return a valid certificate")
+	}
+}


### PR DESCRIPTION
#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue longhorn/longhorn#13306

#### What this PR does / why we need it:

Add `TLSConfigProvider` that reloads certificates from disk on each TLS handshake if the files have changed since the last load. On reload failure the last known-good snapshot is retained and a warning logged -- the provider never downgrades to plaintext.

Wire `TLSConfigProvider` into all services via `NewReloadableServerTLS` and `NewReloadableClientTLS`, and update all `*WithTLS` client constructors to use the reloadable variant.

#### Special notes for your reviewer:

#### Additional documentation or context
