### PR TITLE
fix(vendor): bump longhorn-spdk-engine for ublk target fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,11 +9,10 @@ require (
 	github.com/longhorn/go-common-libs v0.0.0-20260712050051-67a253016448
 	github.com/longhorn/go-spdk-helper v0.6.3-0.20260712050109-6357546afe9a
 	github.com/longhorn/longhorn-engine v1.13.0-dev-20260712
-	github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712
+	github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712.0.20260712132529-3d7109a8cdad
 	github.com/longhorn/types v0.0.0-20260709032252-3d0a3cd8f06f
 	github.com/sirupsen/logrus v1.9.4
 	github.com/urfave/cli v1.22.17
-	github.com/urfave/cli/v3 v3.10.1
 	golang.org/x/sync v0.21.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/longhorn/go-spdk-helper v0.6.3-0.20260712050109-6357546afe9a h1:htOz2
 github.com/longhorn/go-spdk-helper v0.6.3-0.20260712050109-6357546afe9a/go.mod h1:kDYmxxJqiNKlpQKhYdgdts0AXs1sShYRvcLwjEJbhCY=
 github.com/longhorn/longhorn-engine v1.13.0-dev-20260712 h1:rrH01izc8KhLoPBVVk0wt8d029uVoNnfYWqpJFQi7zg=
 github.com/longhorn/longhorn-engine v1.13.0-dev-20260712/go.mod h1:fmERzeUE98TKP8I/OCGkFSW5kuPXNFhzPZIDYBeXfOc=
-github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712 h1:UPIFzAnEPgDXTlL6z8CHA2FbO8dXbsmnONnqqsUpCZ8=
-github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712/go.mod h1:DC0ymSBqu2xOBv/chuIw+ud0vNysY/xMV+ZGk/rlfTs=
+github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712.0.20260712132529-3d7109a8cdad h1:T4PHy2M13cpVVwxrS6fiqp/L+akeTjNWoqTTmXwyhWI=
+github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712.0.20260712132529-3d7109a8cdad/go.mod h1:t1oJ8RLFf6/b7tMgxoIDq/QKAwwr1V28IaRUcekldJo=
 github.com/longhorn/sparse-tools v0.0.0-20260423074222-280e61de741a h1:xb71oeVPI7XZymAAG8ts5deC8s40dnX5IgxTYAB/qnk=
 github.com/longhorn/sparse-tools v0.0.0-20260423074222-280e61de741a/go.mod h1:d8l9nyC8No3PIfYHwZunnBj88y5M4sDM+h6uZyTtaNk=
 github.com/longhorn/types v0.0.0-20260709032252-3d0a3cd8f06f h1:nE+95cq4uc/RUwMVzw6GQDlch7+JHKVo0qXviowWbe0=
@@ -240,7 +240,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli v1.22.17 h1:SYzXoiPfQjHBbkYxbew5prZHS1TOLT3ierW8SYLqtVQ=
 github.com/urfave/cli v1.22.17/go.mod h1:b0ht0aqgH/6pBYzzxURyrM4xXNgsoT/n2ZzwQiEhNVo=
-github.com/urfave/cli/v3 v3.10.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -383,7 +383,7 @@ github.com/longhorn/longhorn-engine/pkg/sync
 github.com/longhorn/longhorn-engine/pkg/types
 github.com/longhorn/longhorn-engine/pkg/util
 github.com/longhorn/longhorn-engine/pkg/util/disk
-# github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712
+# github.com/longhorn/longhorn-spdk-engine v1.13.0-dev-20260712.0.20260712132529-3d7109a8cdad
 ## explicit; go 1.26.0
 github.com/longhorn/longhorn-spdk-engine/pkg/api
 github.com/longhorn/longhorn-spdk-engine/pkg/client
@@ -485,8 +485,6 @@ github.com/slok/goresilience/timeout
 # github.com/urfave/cli v1.22.17
 ## explicit; go 1.11
 github.com/urfave/cli
-# github.com/urfave/cli/v3 v3.10.1
-## explicit; go 1.22
 # github.com/x448/float16 v0.8.4
 ## explicit; go 1.11
 github.com/x448/float16


### PR DESCRIPTION
Pulls in longhorn/longhorn-spdk-engine#594, which bumps go-spdk-helper to restore idempotent ublk target creation in StartUblkInitiator.

Ref: longhorn/longhorn#11977

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
