### PR TITLE
feat(instance): pass the replica host-ACL restriction flag to the SPDK service

### DIFF
--- a/pkg/client/instance.go
+++ b/pkg/client/instance.go
@@ -112,6 +112,7 @@ type ReplicaCreateRequest struct {
 	DiskUUID         string
 	ExposeRequired   bool
 	BackingImageName string
+	RestrictHostACL  bool
 }
 
 type ShardCreateRequest struct {
@@ -200,6 +201,7 @@ func (c *InstanceServiceClient) InstanceCreate(req *InstanceCreateRequest) (*api
 				DiskUuid:         req.Replica.DiskUUID,
 				ExposeRequired:   req.Replica.ExposeRequired,
 				BackingImageName: req.Replica.BackingImageName,
+				RestrictHostAcl:  req.Replica.RestrictHostACL,
 			}
 		case types.InstanceTypeShard:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -210,7 +210,7 @@ func (ops V2DataEngineInstanceOps) InstanceCreate(req *rpc.InstanceCreateRequest
 		}
 		return engineFrontendResponseToInstanceResponse(engineFrontend), nil
 	case types.InstanceTypeReplica:
-		replica, err := c.ReplicaCreate(req.Spec.Name, req.Spec.SpdkInstanceSpec.DiskName, req.Spec.SpdkInstanceSpec.DiskUuid, req.Spec.SpdkInstanceSpec.Size, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.BackingImageName)
+		replica, err := c.ReplicaCreate(req.Spec.Name, req.Spec.SpdkInstanceSpec.DiskName, req.Spec.SpdkInstanceSpec.DiskUuid, req.Spec.SpdkInstanceSpec.Size, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.BackingImageName, req.Spec.SpdkInstanceSpec.RestrictHostAcl)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -2,7 +2,9 @@ package meta
 
 const (
 	// InstanceManagerAPIVersion is used for compatibility check for longhorn-manager
-	InstanceManagerAPIVersion    = 7
+	// 8: SpdkInstanceSpec.restrict_host_acl - the instance manager honors the
+	//    replica host-ACL restriction flag on replica creation
+	InstanceManagerAPIVersion    = 8
 	InstanceManagerAPIMinVersion = 1
 
 	// InstanceManagerProxyAPIVersion is used for compatibility check for longhorn-manager


### PR DESCRIPTION
#### Which issue(s) this PR fixes:

Issue longhorn/longhorn#13699

#### What this PR does / why we need it:

Forwards `SpdkInstanceSpec.restrict_host_acl` to `ReplicaCreate` and bumps `InstanceManagerAPIVersion` to 8.

#### Special notes for your reviewer:

Depends on the longhorn/types and longhorn-spdk-engine PRs; ships together with the longhorn-manager counterpart.

#### Additional documentation or context

`None`
