### PR TITLE
feat(instance): forward v2 data-engine transport to SPDK create calls

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -102,11 +102,11 @@ RUN zypper -n install sg3_utils iproute2
 RUN zypper -n install util-linux-systemd nfs-client nfs4-acl-tools
 RUN zypper clean -a
 
-# Install SPDK dependencies
+# Install SPDK dependencies (--rdma pulls libibverbs/librdmacm runtime libs for the NVMe-oF RDMA transport)
 COPY --from=cbuilder /usr/src/spdk/scripts /usr/src/spdk/scripts
 COPY --from=cbuilder /usr/src/spdk/include /usr/src/spdk/include
 RUN for i in {1..10}; do \
-        bash /usr/src/spdk/scripts/pkgdep.sh && break || sleep 1; \
+        bash /usr/src/spdk/scripts/pkgdep.sh --rdma && break || sleep 1; \
     done
 
 # Copy pre-built binaries from cbuilder and gobuilder

--- a/pkg/client/instance.go
+++ b/pkg/client/instance.go
@@ -149,6 +149,11 @@ type InstanceCreateRequest struct {
 	ShardGroup     ShardGroupCreateRequest
 	DataLayoutType rpc.DataLayoutType
 
+	// DataEngineTransport selects the NVMe-oF transport for the internal
+	// engine<->replica connections of a v2 (SPDK) volume (TCP or RDMA). The
+	// zero value is TCP, preserving the pre-existing default behavior.
+	DataEngineTransport rpc.DataEngineTransport
+
 	// Deprecated: replaced by DataEngine.
 	BackendStoreDriver string
 }
@@ -179,13 +184,14 @@ func (c *InstanceServiceClient) InstanceCreate(req *InstanceCreateRequest) (*api
 		switch req.InstanceType {
 		case types.InstanceTypeEngine:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{
-				Size:              req.Size,
-				ReplicaAddressMap: req.Engine.ReplicaAddressMap,
-				Frontend:          req.Engine.Frontend,
-				SalvageRequested:  req.Engine.SalvageRequested,
-				SnapshotMaxCount:  int32(req.Engine.SnapshotMaxCount),
-				UblkQueueDepth:    int32(req.Engine.UblkQueueDepth),
-				UblkNumberOfQueue: int32(req.Engine.UblkNumberOfQueue),
+				Size:                req.Size,
+				ReplicaAddressMap:   req.Engine.ReplicaAddressMap,
+				Frontend:            req.Engine.Frontend,
+				SalvageRequested:    req.Engine.SalvageRequested,
+				SnapshotMaxCount:    int32(req.Engine.SnapshotMaxCount),
+				UblkQueueDepth:      int32(req.Engine.UblkQueueDepth),
+				UblkNumberOfQueue:   int32(req.Engine.UblkNumberOfQueue),
+				DataEngineTransport: req.DataEngineTransport,
 			}
 		case types.InstanceTypeEngineFrontend:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{
@@ -197,11 +203,12 @@ func (c *InstanceServiceClient) InstanceCreate(req *InstanceCreateRequest) (*api
 			}
 		case types.InstanceTypeReplica:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{
-				Size:             req.Size,
-				DiskName:         req.Replica.DiskName,
-				DiskUuid:         req.Replica.DiskUUID,
-				ExposeRequired:   req.Replica.ExposeRequired,
-				BackingImageName: req.Replica.BackingImageName,
+				Size:                req.Size,
+				DiskName:            req.Replica.DiskName,
+				DiskUuid:            req.Replica.DiskUUID,
+				ExposeRequired:      req.Replica.ExposeRequired,
+				BackingImageName:    req.Replica.BackingImageName,
+				DataEngineTransport: req.DataEngineTransport,
 			}
 		case types.InstanceTypeShard:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{

--- a/pkg/client/instance.go
+++ b/pkg/client/instance.go
@@ -149,10 +149,10 @@ type InstanceCreateRequest struct {
 	ShardGroup     ShardGroupCreateRequest
 	DataLayoutType rpc.DataLayoutType
 
-	// DataEngineTransport selects the NVMe-oF transport for the internal
+	// TransportType selects the NVMe-oF transport for the internal
 	// engine<->replica connections of a v2 (SPDK) volume (TCP or RDMA). The
 	// zero value is TCP, preserving the pre-existing default behavior.
-	DataEngineTransport rpc.DataEngineTransport
+	TransportType rpc.TransportType
 
 	// Deprecated: replaced by DataEngine.
 	BackendStoreDriver string
@@ -191,7 +191,7 @@ func (c *InstanceServiceClient) InstanceCreate(req *InstanceCreateRequest) (*api
 				SnapshotMaxCount:    int32(req.Engine.SnapshotMaxCount),
 				UblkQueueDepth:      int32(req.Engine.UblkQueueDepth),
 				UblkNumberOfQueue:   int32(req.Engine.UblkNumberOfQueue),
-				DataEngineTransport: req.DataEngineTransport,
+				TransportType: req.TransportType,
 			}
 		case types.InstanceTypeEngineFrontend:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{
@@ -208,7 +208,7 @@ func (c *InstanceServiceClient) InstanceCreate(req *InstanceCreateRequest) (*api
 				DiskUuid:            req.Replica.DiskUUID,
 				ExposeRequired:      req.Replica.ExposeRequired,
 				BackingImageName:    req.Replica.BackingImageName,
-				DataEngineTransport: req.DataEngineTransport,
+				TransportType: req.TransportType,
 			}
 		case types.InstanceTypeShard:
 			spdkInstanceSpec = &rpc.SpdkInstanceSpec{

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -198,7 +198,7 @@ func (ops V2DataEngineInstanceOps) InstanceCreate(req *rpc.InstanceCreateRequest
 			req.Spec.SpdkInstanceSpec.ReplicaAddressMap, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.SalvageRequested,
 			req.Spec.SpdkInstanceSpec.SnapshotMaxCount,
 			convertIMDataLayoutTypeToSPDKDataLayoutType(req.DataLayoutType),
-			convertIMDataEngineTransportToSPDKDataEngineTransport(req.Spec.SpdkInstanceSpec.DataEngineTransport))
+			convertIMTransportTypeToSPDKTransportType(req.Spec.SpdkInstanceSpec.TransportType))
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +212,7 @@ func (ops V2DataEngineInstanceOps) InstanceCreate(req *rpc.InstanceCreateRequest
 		return engineFrontendResponseToInstanceResponse(engineFrontend), nil
 	case types.InstanceTypeReplica:
 		replica, err := c.ReplicaCreate(req.Spec.Name, req.Spec.SpdkInstanceSpec.DiskName, req.Spec.SpdkInstanceSpec.DiskUuid, req.Spec.SpdkInstanceSpec.Size, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.BackingImageName,
-			convertIMDataEngineTransportToSPDKDataEngineTransport(req.Spec.SpdkInstanceSpec.DataEngineTransport))
+			convertIMTransportTypeToSPDKTransportType(req.Spec.SpdkInstanceSpec.TransportType))
 		if err != nil {
 			return nil, err
 		}
@@ -1354,17 +1354,17 @@ func convertIMDataLayoutTypeToSPDKDataLayoutType(layout rpc.DataLayoutType) spdk
 	}
 }
 
-// convertIMDataEngineTransportToSPDKDataEngineTransport maps the imrpc
+// convertIMTransportTypeToSPDKTransportType maps the imrpc
 // NVMe-oF transport selector to its spdkrpc equivalent. The zero value
-// (DATA_ENGINE_TRANSPORT_TCP) maps to TCP so instances created by an older
+// (TRANSPORT_TYPE_TCP) maps to TCP so instances created by an older
 // control plane - which never sets the field - keep their historical TCP
 // behavior.
-func convertIMDataEngineTransportToSPDKDataEngineTransport(transport rpc.DataEngineTransport) spdkrpc.DataEngineTransport {
+func convertIMTransportTypeToSPDKTransportType(transport rpc.TransportType) spdkrpc.TransportType {
 	switch transport {
-	case rpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA:
-		return spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA
+	case rpc.TransportType_TRANSPORT_TYPE_RDMA:
+		return spdkrpc.TransportType_TRANSPORT_TYPE_RDMA
 	default:
-		return spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_TCP
+		return spdkrpc.TransportType_TRANSPORT_TYPE_TCP
 	}
 }
 

--- a/pkg/instance/instance.go
+++ b/pkg/instance/instance.go
@@ -197,7 +197,8 @@ func (ops V2DataEngineInstanceOps) InstanceCreate(req *rpc.InstanceCreateRequest
 		engine, err := c.EngineCreate(req.Spec.Name, req.Spec.VolumeName, req.Spec.SpdkInstanceSpec.Frontend, req.Spec.SpdkInstanceSpec.Size,
 			req.Spec.SpdkInstanceSpec.ReplicaAddressMap, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.SalvageRequested,
 			req.Spec.SpdkInstanceSpec.SnapshotMaxCount,
-			convertIMDataLayoutTypeToSPDKDataLayoutType(req.DataLayoutType))
+			convertIMDataLayoutTypeToSPDKDataLayoutType(req.DataLayoutType),
+			convertIMDataEngineTransportToSPDKDataEngineTransport(req.Spec.SpdkInstanceSpec.DataEngineTransport))
 		if err != nil {
 			return nil, err
 		}
@@ -210,7 +211,8 @@ func (ops V2DataEngineInstanceOps) InstanceCreate(req *rpc.InstanceCreateRequest
 		}
 		return engineFrontendResponseToInstanceResponse(engineFrontend), nil
 	case types.InstanceTypeReplica:
-		replica, err := c.ReplicaCreate(req.Spec.Name, req.Spec.SpdkInstanceSpec.DiskName, req.Spec.SpdkInstanceSpec.DiskUuid, req.Spec.SpdkInstanceSpec.Size, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.BackingImageName)
+		replica, err := c.ReplicaCreate(req.Spec.Name, req.Spec.SpdkInstanceSpec.DiskName, req.Spec.SpdkInstanceSpec.DiskUuid, req.Spec.SpdkInstanceSpec.Size, req.Spec.PortCount, req.Spec.SpdkInstanceSpec.BackingImageName,
+			convertIMDataEngineTransportToSPDKDataEngineTransport(req.Spec.SpdkInstanceSpec.DataEngineTransport))
 		if err != nil {
 			return nil, err
 		}
@@ -1349,6 +1351,20 @@ func convertIMDataLayoutTypeToSPDKDataLayoutType(layout rpc.DataLayoutType) spdk
 		return spdkrpc.DataLayoutType_DATA_LAYOUT_TYPE_SHARDED
 	default:
 		return spdkrpc.DataLayoutType_DATA_LAYOUT_TYPE_REPLICATED
+	}
+}
+
+// convertIMDataEngineTransportToSPDKDataEngineTransport maps the imrpc
+// NVMe-oF transport selector to its spdkrpc equivalent. The zero value
+// (DATA_ENGINE_TRANSPORT_TCP) maps to TCP so instances created by an older
+// control plane - which never sets the field - keep their historical TCP
+// behavior.
+func convertIMDataEngineTransportToSPDKDataEngineTransport(transport rpc.DataEngineTransport) spdkrpc.DataEngineTransport {
+	switch transport {
+	case rpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA:
+		return spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_RDMA
+	default:
+		return spdkrpc.DataEngineTransport_DATA_ENGINE_TRANSPORT_TCP
 	}
 }
 


### PR DESCRIPTION
Part of longhorn/longhorn#13796. **Depends on longhorn/types#121 and longhorn/longhorn-spdk-engine#654.**

Forward `DataEngineTransport` from the imrpc `SpdkInstanceSpec` through to the spdkrpc engine/replica create calls (new mapper `convertIMDataEngineTransportToSPDKDataEngineTransport`, zero means TCP). Adds the field to the IM client's `InstanceCreateRequest` so the manager can select transport declaratively (replaces an earlier env-var stopgap). Build the runtime image with `pkgdep.sh --rdma` so it ships `libibverbs`/`librdmacm` for the RDMA transport. Default behavior unchanged (unset means TCP).

Files: `pkg/instance/instance.go`, `pkg/client/instance.go`, `package/Dockerfile`.
