### PR TITLE
fix(revert): revert "feat(proxy): allowlist AWS_SIGN_ACCEPT_ENCODING (backport #1615)"

### DIFF
--- a/pkg/proxy/backup_test.go
+++ b/pkg/proxy/backup_test.go
@@ -78,7 +78,6 @@ func TestSetEnv_AcceptsAllowlistedCredentials(t *testing.T) {
 		"AWS_ENDPOINTS",
 		"AWS_CERT",
 		"VIRTUAL_HOSTED_STYLE",
-		"AWS_SIGN_ACCEPT_ENCODING",
 		"CIFS_USERNAME",
 		"CIFS_PASSWORD",
 		"AZBLOB_ACCOUNT_NAME",

--- a/pkg/proxy/env_allowlist.go
+++ b/pkg/proxy/env_allowlist.go
@@ -28,10 +28,6 @@ var backupEnvAllowlist = map[string]struct{}{
 	btypes.AWSCert:            {},
 	btypes.VirtualHostedStyle: {},
 
-	// Selects whether Accept-Encoding is part of the SigV4 signature. It is a
-	// signing option, not a credential, and carries no secret.
-	btypes.AWSSignAcceptEncoding: {},
-
 	// CIFS
 	btypes.CIFSUsername: {},
 	btypes.CIFSPassword: {},


### PR DESCRIPTION
Reverts longhorn/longhorn-instance-manager#1623

Revert the implementation because the fix is only applied to v1.13.0+.