### PR TITLE
feat(proxy): bump proxy API version for the backup env allowlist

### DIFF
--- a/pkg/meta/version.go
+++ b/pkg/meta/version.go
@@ -6,7 +6,7 @@ const (
 	InstanceManagerAPIMinVersion = 1
 
 	// InstanceManagerProxyAPIVersion is used for compatibility check for longhorn-manager
-	InstanceManagerProxyAPIVersion    = 7
+	InstanceManagerProxyAPIVersion    = 8
 	InstanceManagerProxyAPIMinVersion = 1
 
 	// InstanceManagerDiskServiceAPIVersion used to communicate with the user e.g. longhorn-manager


### PR DESCRIPTION




#### Which issue(s) this PR fixes:

Issue Longhorn/longhorn#13911

#### What this PR does / why we need it:

Allowlisting AWS_SIGN_ACCEPT_ENCODING changed which backup requests the proxy accepts, but the proxy API version stayed at 7, so longhorn-manager has no way to tell whether a peer accepts the key. An instance manager whose allowlist predates the key rejects the whole SnapshotBackup or BackupRestore request, which happens on every live upgrade until the engines move to the new instance manager.

Bump InstanceManagerProxyAPIVersion so longhorn-manager can gate the key on the peer's capability.

#### Special notes for your reviewer:

#### Additional documentation or context
